### PR TITLE
Fix missing images in Talisman wallet documentation

### DIFF
--- a/docs/wallets/wallets-talisman.mdx
+++ b/docs/wallets/wallets-talisman.mdx
@@ -102,7 +102,7 @@ Open your Talisman browser estension and select the Acurast account. Then click 
 
 Select it and the bullet point will turn green:
 
-ThemedImage
+<ThemedImage
   sources={{
     light: useBaseUrl("/guide/talisman/selectacc_talisman.png"),
     dark: useBaseUrl("/guide/talisman/selectacc_talisman.png"),
@@ -112,7 +112,7 @@ ThemedImage
 
 5. Go back to the hub.acurast.com page and click *Talisman*. The account will now appear under *Select Account*. Click it
 
-ThemedImage
+<ThemedImage
   sources={{
     light: useBaseUrl("/guide/talisman/selacc_talisman.png"),
     dark: useBaseUrl("/guide/talisman/selacc_talisman.png"),


### PR DESCRIPTION
## Summary
- Fixed syntax errors preventing the last two images from displaying on the Talisman wallet page
- Added missing `<` opening brackets to two `ThemedImage` components

## Changes
- Line 105: Fixed `ThemedImage` component for `selectacc_talisman.png`
- Line 115: Fixed `ThemedImage` component for `selacc_talisman.png`

## Test plan
- [ ] Verify that the image showing the green bullet point when account is selected now displays correctly
- [ ] Verify that the image showing account selection in the hub now displays correctly
- [ ] Confirm all images on the Talisman wallet page are rendering properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)