### PR TITLE
Add comprehensive compute provider onboarding guide

### DIFF
--- a/docs/acurast-protocol/architecture/instances.mdx
+++ b/docs/acurast-protocol/architecture/instances.mdx
@@ -26,7 +26,7 @@ The canary network uses tokens with governance and staking utility. The service 
 
    Comparable to Curve’s voted escrow model, the stake weight is based on the user’s selected lock time duration of the stake provided. The exact mechanics will be outlined in a future blog post.
 
-   With the activation of the Alpha-Net, the block production will be rewarded, the rewards will be paid out of the Acurast protocol’s adaptive inflation model. Sudo will remain active for this phase.
+   With the activation of the Alpha-Net, the block production will be rewarded, the rewards will be distributed from the Acurast protocol's adaptive inflation model. Sudo will remain active for this phase.
 
 1. **Beta-Net**
    This phase removes sudo and migrates governance to the active stakers and enables token transfers.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -17,7 +17,7 @@ This isn’t just another DePIN protocol — it’s a game-changer that’s rede
 
 ### How can you provide compute with your phone on Acurast?
 
-Get started as a [Processor](/acurast-processors) on Acurast and provide compute to earn rewards, either with Lite or Core:
+Get started as a [Processor](/acurast-processors) on Acurast and provide compute to receive rewards, either with Lite or Core:
 
 #### **Acurast Processor Lite**
 
@@ -87,7 +87,7 @@ Thank you for your continued support.
 - Converted and locked ACU can be Staked in Staked Compute Pool from Day 1 of Mainnet.
   ⟶ Staking Rewards are transferable (not locked) and claimable every epoch (1.5h)
 - Converted and locked ACU can be used to participate in on-chain Governance
-- If you continue to provide compute, you’ll earn ACU rewards, that are transferable, from the Compute Pool.
+- If you continue to provide compute, you'll receive ACU rewards, that are transferable, from the Compute Pool.
 
 ### Is there an Airdrop?
 
@@ -159,7 +159,7 @@ You do. You’re in complete control. Your device is connected to the decentrali
 
 Because Lite uses the Android work profile, you’ll have to remove it completely to uninstall the app from your device.
 
-If you have set up Lite with “Get Started” without a connection to your Acurast Hub, make sure that you backup your secret before removing the app; otherwise, you will lose access to your earned cACU.
+If you have set up Lite with "Get Started" without a connection to your Acurast Hub, make sure that you backup your secret before removing the app; otherwise, you will lose access to your cACU.
 
 Uninstalling Processor Lite:
 

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -93,7 +93,7 @@ A simplified representation of the Level 2 flow:
 **Key takeaways:**
 
 - Developers create Acurast Deployments through the Acurast Hub with a wallet from their ecosystem e.g., Metamask for Ethereum
-- Rewards and transaction fees are paid in a native asset e.g., ETH
+- Rewards and transaction fees are provided in a native asset e.g., ETH
 - Acurast Hyperdrive is used for cross-chain communication
 
 ## Integrations

--- a/docs/processors/acurast-processors.mdx
+++ b/docs/processors/acurast-processors.mdx
@@ -30,7 +30,7 @@ Install the Acurast Processor Lite application on Android or iOS to get started.
 - **Deployment Execution**: Tokens (cACU on Canary, ACU on Mainnet) are rewarded when a processor's compute power is used by developers to run code. Developers that deploy to the Acurast Cloud provide a reward for the compute power used. When your Processor has been selected, you'll receive part of that reward.
 - **Benchmark Rewards**: Providers receive rewards based on the [benchmarks](/acurast-processors/benchmarks) of their participating devices. On Canary, a total of 12'500 cACU are distributed per epoch (roughly every 1.5 hours). These rewards are split up to the different benchmarks pools and each phone competes with the others in the 4 benchmark pools. Higher specs usually lead to higher Benchmark Rewards.
 - **Cloud Rebellion**: Join the [Cloud Rebellion](https://rebellion.acurast.com/) and harvest MIST ☁️ points. Become a Rebel and cloud-harvest MIST (points) by completing quests, onboarding Processors, and inviting others to join the Rebellion.
-- ~~**Bootstrapping**: Earn 250 cACU each month in Bootstrapping Rewards. Run your Processor, connected to the internet, for a month and earn 250 cACU in bootstrapping rewards. You will earn a fraction of the full reward each hour.~~ (has been sundowned in favor of the Benchmark Rewards)
+- ~~**Bootstrapping**: Receive 250 cACU each month in Bootstrapping Rewards. Run your Processor, connected to the internet, for a month and receive 250 cACU in bootstrapping rewards. You will receive a fraction of the full reward each hour.~~ (has been sundowned in favor of the Benchmark Rewards)
 
 ## Recommended Phones
 

--- a/docs/processors/become-compute-provider.mdx
+++ b/docs/processors/become-compute-provider.mdx
@@ -1,0 +1,199 @@
+---
+title: Become an Acurast Compute Provider
+slug: /processors/become-compute-provider
+---
+
+import ThemedImage from "@theme/ThemedImage";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
+Join Acurast's decentralized compute network and start receiving rewards by providing compute power with your smartphone. This guide will walk you through everything you need to get started as a Compute Provider.
+
+## What is a Compute Provider?
+
+Compute Providers are people who run the Acurast Processor App to provide infrastructure for Acurast's decentralized compute network. As a Compute Provider, you provide the compute power of your phone to developers who run their applications (called Deployments) on the Acurast network. In return, you receive rewards in the form of tokens.
+
+## What you need to become a Compute Provider
+
+Getting started as a Compute Provider is simple. Here's what you need:
+
+**One or more Compatible Smartphones**
+- **Android**: Android 12 or newer (non-rooted, locked bootloader)
+- **iOS**: iPhone 6S or newer (iOS 15+)
+- Higher specs (CPU, RAM, Storage) will potentially result in higher rewards
+- Check the [Recommended Phones list ↗](https://docs.google.com/spreadsheets/d/1ZvzmMVey4CM2tuif_zJfWiIxH1qkgA-l7BNJMw4vh54/edit#gid=1844886586) for optimal reward potential
+
+**Internet Connection**
+- Stable Wi-Fi or mobile data connection
+- Reliable connectivity ensures consistent uptime and maximum rewards
+
+**Power Source**
+- Keep your device charged or connected to power
+- Continuous operation maximizes your rewards
+
+**Acurast Wallet**
+- Created automatically when you install the Acurast Processor app
+- Or import an existing wallet if you already have one
+
+That's it! No technical expertise required - the Acurast Processor app handles everything else.
+
+## Quick Start Guide
+
+### Step 1: Check Device Compatibility
+
+Before getting started, make sure your device meets the requirements:
+
+**Android Requirements:**
+- Android 12 or newer
+- Device must not be rooted
+- Bootloader must be locked
+
+**iOS Requirements:**
+- iPhone 6S or newer
+- iOS 15 or newer
+
+### Step 2: Get an Acurast Compatible Wallet
+
+Before setting up your Processor, you'll need a wallet to receive your rewards. We recommend using a substrate-based wallet for the best experience with Acurast.
+
+**Recommended Wallets:**
+- **[Talisman ↗](https://talisman.xyz/)** - Full-featured Substrate wallet
+- **[SubWallet ↗](https://www.subwallet.app/)** - Multi-chain Substrate wallet
+
+For detailed wallet setup guides, see our [Wallet Documentation](/wallets/wallet-overview).
+
+**Quick Setup (Talisman):**
+
+1. Install the [Talisman browser extension ↗](https://talisman.xyz/)
+2. Click "New Wallet" and create a strong password
+3. Write down your recovery phrase and store it safely (never share this!)
+4. Add Acurast network: Click the network dropdown → Search for "Acurast" → Enable it
+
+### Step 3: Choose Your Processor Type
+
+Acurast offers two types of Processors:
+
+<div style={{maxWidth: '640px', margin: '20px 0'}}>
+  <div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden'}}>
+    <iframe
+      style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+      src="https://www.youtube.com/embed/aVKVflF-rLU"
+      title="Acurast Processor Types"
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen>
+    </iframe>
+  </div>
+</div>
+
+**Acurast Processor Core** (Android only)
+- Dedicated device setup for maximum performance
+- Requires factory reset of your Android phone
+- Only the Acurast Processor app will run on this phone (everything else is completely locked down)
+- Best for serious compute providers
+- [Setup via Acurast Hub ↗](https://hub.acurast.com/)
+
+**Acurast Processor Lite** (Android & iOS)
+- Runs on your everyday phone in edge-times (e.g. while you sleep and charge)
+- No factory reset required
+- Easy to get started
+- [Download for Android ↗](https://play.google.com/store/apps/details?id=com.acurast.attested.executor.sbs.canary)
+- [Download for iOS ↗](https://apps.apple.com/us/app/acurast-processor/id6517361921)
+
+### Step 4: Install and Setup
+
+**For Processor Core:**
+
+1. Factory reset your Android phone
+2. Visit [Acurast Hub ↗](https://hub.acurast.com/) and connect with your wallet
+3. Follow the detailed setup instructions for dedicated processors
+4. Lock down the device as a dedicated compute provider
+
+<div style={{maxWidth: '640px', margin: '20px 0'}}>
+  <div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden'}}>
+    <iframe
+      style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+      src="https://www.youtube.com/embed/uLpBRUnmiPY"
+      title="Acurast Processor Core Setup"
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen>
+    </iframe>
+  </div>
+</div>
+
+**For Processor Lite:**
+
+1. Download the app from [Google Play ↗](https://play.google.com/store/apps/details?id=com.acurast.attested.executor.sbs.canary) or [Apple App Store ↗](https://apps.apple.com/us/app/acurast-processor/id6517361921)
+2. Open the app and give the required permissions
+3. Visit [Acurast Hub ↗](https://hub.acurast.com/), connect your wallet and use 'Onboard with hub'. Alternatively tap "Get Started" and a wallet will be created for you on the app.
+4. Complete the initial setup wizard
+5. Keep your device connected to the internet
+
+<div style={{maxWidth: '640px', margin: '20px 0'}}>
+  <div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden'}}>
+    <iframe
+      style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+      src="https://www.youtube.com/embed/2Pxw2u0pZ_E"
+      title="Acurast Processor Lite Setup"
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen>
+    </iframe>
+  </div>
+</div>
+
+### Step 5: Start Receiving Rewards
+
+Once your Processor is set up and running, you'll automatically start receiving rewards:
+
+**Deployment Execution Rewards**
+- Receive tokens (cACU on Canary, ACU on Mainnet) when developers use your compute power
+- Rewards are distributed when your Processor executes code deployments
+- The more deployments you execute, the more you receive
+
+**Benchmark Rewards**
+- Receive based on your device's [benchmark performance](/acurast-processors/benchmarks)
+- 12,500 cACU distributed per epoch (~1.5 hours) on Canary
+- Rewards split across 4 benchmark pools (CPU, memory, network, storage)
+- Higher-spec devices typically receive more
+
+**Cloud Rebellion Points**
+- Join the [Cloud Rebellion ↗](https://rebellion.acurast.com/) to receive MIST points
+- Complete quests and onboard more Compute Providers
+- Invite others to join and receive additional rewards
+
+## Best Practices
+
+To maximize your rewards and ensure smooth operation:
+
+- **Keep your device connected to the internet** - Your Processor needs stable internet to receive and execute deployments
+
+- **Ensure adequate power** - Keep your device charged or connected to power
+
+- **Use recommended devices** - Higher-spec phones from the recommended list will receive more benchmark rewards
+
+- **Run multiple processors** - Scale your compute provision by running [multiple devices](/acurast-processors/multiple-processors)
+
+- **Monitor performance** - Check your benchmark scores and uptime regularly
+
+## Next Steps
+
+Now that you're set up as a compute provider, explore these resources:
+
+- Learn about [Processor Lite and Core](/acurast-processors) in detail
+- Understand how [Benchmarks](/acurast-processors/benchmarks) affect your rewards
+- Scale up by running [Multiple Processors](/acurast-processors/multiple-processors)
+- Join the [Cloud Rebellion ↗](https://rebellion.acurast.com/)
+- Follow us on [X ↗](https://x.com/Acurast)
+- Join the community on [Discord](https://discord.gg/wqgC6b6aKe) or [Telegram](https://t.me/acurastnetwork)
+
+## Need Help?
+
+If you encounter any issues during setup or have questions:
+
+- Check the [FAQ](/faq) for common questions
+- Join our [Discord community ↗](https://discord.gg/wqgC6b6aKe)
+- Reach out on [Telegram ↗](https://t.me/acurastnetwork)
+- Contact support through the [Acurast Hub ↗](https://hub.acurast.com/)
+
+Welcome to the Acurast network!

--- a/docs/processors/benchmarks.mdx
+++ b/docs/processors/benchmarks.mdx
@@ -6,7 +6,7 @@ slug: /acurast-processors/benchmarks
 import ThemedImage from "@theme/ThemedImage";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-Benchmark tests on Acurast phones are vital to determine the compute power of the participating devices. The compute metrics determined by these benchmark tests are relevant for **matching phones** to the right tasks based on their capabilities, **calculating benchmark rewards** paid for the provision of phones, and **determining [staked compute rewards](/staked-compute)**. Better hardware usually leads to a higher benchmark score.
+Benchmark tests on Acurast phones are vital to determine the compute power of the participating devices. The compute metrics determined by these benchmark tests are relevant for **matching phones** to the right tasks based on their capabilities, **calculating benchmark rewards** distributed for the provision of phones, and **determining [staked compute rewards](/staked-compute)**. Better hardware usually leads to a higher benchmark score.
 
 ## Overview
 

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -30,7 +30,7 @@ Here’s how Acurast is scaling fast—and sustainably:
 
 ### 1. Mainnet Launch → Permissionless, Global Access
 
-With the **Genesis Mainnet and TGE launching in Q3 2025**, Acurast becomes fully open, decentralized, and permissionless. Anyone with a smartphone can start earning as a compute provider. Anyone with workloads, from solo builders to AI startups, can deploy confidential applications on a decentralized network backed by hundreds of thousands of real, verifiable phones.
+With the **Genesis Mainnet and TGE launching in Q3 2025**, Acurast becomes fully open, decentralized, and permissionless. Anyone with a smartphone can become a compute provider. Anyone with workloads, from solo builders to AI startups, can deploy confidential applications on a decentralized network backed by hundreds of thousands of real, verifiable phones.
 
 Mainnet is Acurast’s on-ramp to true global accessibility, where compute is no longer gatekept by geography, capital, or centralized infrastructure.
 

--- a/docs/staked-compute.mdx
+++ b/docs/staked-compute.mdx
@@ -14,10 +14,10 @@ The specifics on this page are currently under review and subject to change.
 
 ## TLDR — why this matters
 
-- Staked compute plays a significant role for Acurast: 70% of the inflation is allocated to “Staked Compute”
+- Staked compute plays a significant role for Acurast: 70% of the inflation is allocated to "Staked Compute"
 - Accessible first design: Onboard smartphone compute without token purchase or gatekeepers
-- People without hardware can still earn by delegating their stake to compute providers
-- Compute providers can accept delegation and earn additional rewards
+- People without hardware can still receive rewards by delegating their stake to compute providers
+- Compute providers can accept delegation and receive additional rewards
 - Staked compute can be restaked
 
 ## Introduction
@@ -105,7 +105,7 @@ It’s important to note that `“benchmark_in_heartbeat”` should be seen as t
 
 ### Stake Delegation
 
-Not every staker will need to have their own hardware setup. They will be able to earn rewards from staking by delegating their stake to other compute providers on the network.
+Not every staker will need to have their own hardware setup. They will be able to receive rewards from staking by delegating their stake to other compute providers on the network.
 
 Every compute provider can stake and accept a delegated stake. As shown in the previous formula, the total amount of stake “stake_weight” is the sum of the own + delegated stake. To avoid centralisation and align slashing, the target is set at a 9:1 ratio of own stake vs. allowed delegated stake. If a compute provider decides to allow delegations, they must specify a fee applied programmatically on a protocol level during the reward distribution to the delegators.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -36,7 +36,16 @@ const sidebars = {
     {
       type: "category",
       label: "Processors",
-      items: ["processors/acurast-processors", "processors/benchmarks", "processors/multiple-processors"],
+      items: [
+        {
+          type: "doc",
+          id: "processors/become-compute-provider",
+          label: "Become a Compute Provider",
+        },
+        "processors/acurast-processors",
+        "processors/benchmarks",
+        "processors/multiple-processors"
+      ],
       collapsed: false,
     },
 


### PR DESCRIPTION
## Summary

- Added new **"Become a Compute Provider"** documentation page with comprehensive onboarding guide
- Updated terminology across all documentation to use "receive" instead of "earn" and "distributed" instead of "paid"
- Integrated video tutorials for both Processor Core and Lite setup
- Reorganized Processors sidebar navigation with new onboarding page as the first entry

## Changes

### New Content
- Created `/docs/processors/become-compute-provider.mdx` with:
  - Clear explanation of what a Compute Provider is
  - Requirements checklist (devices, internet, power, wallet)
  - Step-by-step onboarding guide (5 steps)
  - Wallet setup instructions (Talisman, SubWallet)
  - Embedded setup videos for Core and Lite
  - Best practices section
  - Links to additional resources

### Documentation Updates
- **Terminology changes** across all docs:
  - `faq.mdx`: Updated 3 instances
  - `acurast-processors.mdx`: Updated bootstrapping section
  - `benchmarks.mdx`: Updated reward distribution language
  - `staked-compute.mdx`: Updated delegation language
  - `instances.mdx`: Updated reward distribution language
  - `integrations.mdx`: Updated payment language
  - `roadmap.mdx`: Updated onboarding language

### Navigation
- Updated `sidebars.js` to feature new onboarding page as first item in Processors category
- Custom sidebar label: "Become a Compute Provider"
- Page title: "Become an Acurast Compute Provider"

## Videos Added
- Processor types overview: https://www.youtube.com/watch?v=aVKVflF-rLU
- Processor Core setup: https://www.youtube.com/watch?v=uLpBRUnmiPY
- Processor Lite setup: https://www.youtube.com/watch?v=2Pxw2u0pZ_E

## Test plan
- [x] Verify all documentation links work correctly
- [x] Confirm video embeds display properly
- [x] Check sidebar navigation shows new page first
- [x] Validate no local config files included in commit
- [x] Review terminology consistency across all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)