### PR TITLE
Update slashing maximum penalty to 0.003424657534%

### DIFF
--- a/docs/staked-compute/slashing.mdx
+++ b/docs/staked-compute/slashing.mdx
@@ -21,23 +21,23 @@ When a committer's Current Compute falls below their Committed Compute in any of
 
 ### How Penalties Are Calculated
 
-Once slashing is triggered, penalties are calculated independently for each Benchmark Metric where there's a shortfall. The slashing amount for each metric is determined by multiplying the stake amount by the maximum slash rate (1% per epoch), the metric's weight, and the percentage shortfall.
+Once slashing is triggered, penalties are calculated independently for each Benchmark Metric where there's a shortfall. The slashing amount for each metric is determined by multiplying the stake amount by the maximum slash rate (0.003424657534% per epoch), the metric's weight, and the percentage shortfall.
 
-For example, if a committer with a 1,000-token stake falls 50% short on RAM (which has a weight of 0.4615), they would be slashed 2.3075 tokens for that metric alone. If they have shortfalls across multiple metrics, each penalty is calculated separately and then summed together - though the total can never exceed 1% of the stake per epoch.
+For example, if a committer with a 1,000-token stake falls 50% short on RAM (which has a weight of 0.4615), they would be slashed 0.0079 tokens for that metric alone. If they have shortfalls across multiple metrics, each penalty is calculated separately and then summed together - though the total can never exceed 0.003424657534% of the stake per epoch.
 
 ### Slashing Examples
 
 _Example 1: Complete Loss of Compute_
 
-A committer has a 1,000-token stake. In an observed epoch, their Current Compute falls 100% short in all four metrics (CPU Single, CPU Multi, RAM, and Storage). Since they failed to provide any of their committed compute, they face the maximum penalty of 1% of their stake, resulting in a total slash of 10 tokens. This breaks down as: 2.307 tokens for CPU Single Core, 2.307 tokens for CPU Multi Core, 4.615 tokens for RAM, and 0.769 tokens for Storage.
+A committer has a 1,000-token stake. In an observed epoch, their Current Compute falls 100% short in all four metrics (CPU Single, CPU Multi, RAM, and Storage). Since they failed to provide any of their committed compute, they face the maximum penalty of 0.003424657534% of their stake per epoch, resulting in a total slash of 0.0342 tokens for this epoch. This breaks down as: 0.0079 tokens for CPU Single Core, 0.0079 tokens for CPU Multi Core, 0.0158 tokens for RAM, and 0.0026 tokens for Storage.
 
 _Example 2 (fictional): Partial Loss of exactly 50% Across All Metrics_
 
-A committer has a 1,000-token stake. In an observed epoch, their compute falls 50% short across all four metrics. They are slashed proportionally: 1.1535 tokens for CPU Single Core, 1.1535 tokens for CPU Multi Core, 2.3075 tokens for RAM, and 0.3845 tokens for Storage - totaling 5 tokens (0.5% of their stake).
+A committer has a 1,000-token stake. In an observed epoch, their compute falls 50% short across all four metrics. They are slashed proportionally for this epoch: 0.0040 tokens for CPU Single Core, 0.0040 tokens for CPU Multi Core, 0.0079 tokens for RAM, and 0.0013 tokens for Storage - totaling 0.0171 tokens (0.00171% of their stake per epoch).
 
 _Example 3 (realistic): Variable Shortfalls_
 
-A committer has a 1,000-token stake. In an observed epoch, their compute falls short by different amounts: 12% in CPU Single Core, 15% in CPU Multi Core, 10% in RAM, and 12% in Storage. The resulting penalties are: 0.27684 tokens for CPU Single Core, 0.34605 tokens for CPU Multi Core, 0.4615 tokens for RAM, and 0.09228 tokens for Storage - totaling approximately 1.18 tokens slashed.
+A committer has a 1,000-token stake. In an observed epoch, their compute falls short by different amounts: 12% in CPU Single Core, 15% in CPU Multi Core, 10% in RAM, and 12% in Storage. The resulting penalties for this epoch are: 0.000948 tokens for CPU Single Core, 0.001185 tokens for CPU Multi Core, 0.001580 tokens for RAM, and 0.000316 tokens for Storage - totaling approximately 0.0040 tokens slashed for this epoch.
 
 
 ### What Happens to Slashed Tokens


### PR DESCRIPTION
## Summary
- Updated maximum slashing penalty from 1% to 0.003424657534% per epoch
- Recalculated all token amounts in the three slashing examples to reflect the new penalty rate
- Added clarification that slashing is calculated per epoch throughout the examples

## Test plan
- [ ] Review the slashing examples section on `/staked-compute/slashing` in the dev server
- [ ] Verify all calculations are correct based on the new 0.003424657534% maximum penalty rate
- [ ] Confirm that the per-epoch clarifications read naturally in the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)