### PR TITLE
doc: clarify delegation fee can be decreased but not increased

### DIFF
--- a/docs/staked-compute/staking-glossary.mdx
+++ b/docs/staked-compute/staking-glossary.mdx
@@ -79,7 +79,7 @@ A percentage of the slashed amount, that is given to the Slasher as a reward for
 Detaching a running Delegation from one Committer and attaching it to a new Committer. Can only be done if the new Committer shares the exact same or higher parameters (Committed Compute, Staked Tokens, Cooldown duration) than the previous Committer and is not in Cooldown.
 
 ### Delegation Fee
-A fee Committers can set once upon creating a Stake and will receive from the rewards of the Delegations attached to their stake. The Delegation fee can not change during the lifetime of a Stake.
+A fee Committers can set once upon creating a Stake and will receive from the rewards of the Delegations attached to their stake. The Delegation fee cannot be increased during the lifetime of a Stake, but it can be decreased.
 
 The delegation fee is expressed as a percentage and is deducted from the delegator's earned rewards before distribution. This fee compensates committers for maintaining reliable hardware and high compute capacity that benefits all delegators staking with them.
 


### PR DESCRIPTION
## Summary
- Updated Delegation Fee definition in staking-glossary.mdx to clarify that delegation fees cannot be increased during the lifetime of a stake, but can be decreased
- This provides more accurate information for committers and delegators about fee flexibility

## Test plan
- [ ] Verify the documentation renders correctly at http://localhost:3000/staked-compute/staking-glossary
- [ ] Review that the delegation fee description is clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)