### PR TITLE
doc: add delegation states and update slashing documentation

### DIFF
--- a/docs/staked-compute/slashing.mdx
+++ b/docs/staked-compute/slashing.mdx
@@ -17,9 +17,9 @@ This mechanism incentivizes providers to actively maintain their deployed Acuras
 
 ### When Slashing Occurs
 
-When a committer's Current Compute falls below their Committed Compute in any of the four benchmark metrics during an epoch, they become slashable for that epoch. Slashing must be triggered on-chain by a **Slasher**- anyone with an Acurast account who detects the violation.
+When a committer's Current Compute falls below their Committed Compute in any of the four benchmark metrics during an epoch, they become slashable for that epoch. Slashing must be triggered on-chain by a **Slasher**- anyone with an Acurast account who detects the violation. Slashing can be triggered earliest in the epoch after the epoch where the commitment was violated.
 
-### How Penalties Are Calculated
+### How Slashing Penalties Are Calculated
 
 Once slashing is triggered, penalties are calculated independently for each Benchmark Metric where there's a shortfall. The slashing amount for each metric is determined by multiplying the stake amount by the maximum slash rate (0.003424657534% per epoch), the metric's weight, and the percentage shortfall.
 

--- a/docs/staked-compute/staking-glossary.mdx
+++ b/docs/staked-compute/staking-glossary.mdx
@@ -88,6 +88,12 @@ The delegation fee is expressed as a percentage and is deducted from the delegat
 ### Delegation Capacity
 The amount of delegations a Committer can accept.
 
+### Stale Delegation
+A Delegation is stale if the Committer it was delegated to did trigger a cooldown which did end. A stale delegation will not earn any rewards and should be finalized.
+
+### Committer in Cooldown
+A delegation shows "Committer in cooldown" to indicate that the Committer this delegation was delegated to, started the cooldown. All following rewards will be halved, while slashing penalty will stay the same. Delegators can choose to trigger their own cooldown or to delegate to a different committer.
+
 ## Time & Measurement
 
 ### Epoch


### PR DESCRIPTION
## Summary
- Added two new glossary terms in staking-glossary.mdx:
  - **Stale Delegation**: Explains that a delegation is stale if the committer's cooldown has ended, and that stale delegations don't earn rewards and should be finalized
  - **Committer in Cooldown**: Clarifies that when a committer enters cooldown, delegator rewards are halved while slashing penalties remain unchanged, and delegators can either trigger their own cooldown or redelegate

- Updated slashing.mdx:
  - Renamed section from "How Penalties Are Calculated" to "How Slashing Penalties Are Calculated" for better clarity
  - Added timing information that slashing can be triggered earliest in the epoch after the epoch where the commitment was violated

## Test plan
- [ ] Verify the documentation renders correctly at http://localhost:3000/staked-compute/staking-glossary
- [ ] Verify the documentation renders correctly at http://localhost:3000/staked-compute/slashing
- [ ] Check that new delegation state definitions are clear and accurate
- [ ] Review slashing timing information is correctly presented

🤖 Generated with [Claude Code](https://claude.com/claude-code)