### PR TITLE
doc: update processor rewards structure and benchmark measurement

### DIFF
--- a/docs/processors/rewards.mdx
+++ b/docs/processors/rewards.mdx
@@ -10,23 +10,28 @@ As a Compute Provider running Acurast Processors, you receive rewards for contri
 
 ## Reward Types
 
-### Deployment Execution
+### Deployment Rewards
 
-Tokens (cACU on Canary, ACU on Mainnet) are rewarded when a processor's compute power is used by developers to run code. Developers that deploy to the Acurast Cloud provide a reward for the compute power used. When your Processor has been selected, you'll receive part of that reward.
+Tokens (cACU on Canary, ACU on Mainnet) are rewarded when a processor's compute power is used by developers to run code. Developers that deploy to the Acurast Cloud pay a fee for the compute power used. When your Processor has been matched and does execute a deployment, you'll receive a share part of those fees collected.
 
-### Benchmark Rewards
+### Base Benchmark Rewards (Compute Pool)
 
-Providers receive rewards based on the [benchmarks](/acurast-processors/benchmarks) of their participating devices. On Canary, a total of 12'500 cACU are distributed per epoch (roughly every 1.5 hours). These rewards are split up to the different benchmarks pools and each phone competes with the others in the 4 benchmark pools. Higher specs usually lead to higher Benchmark Rewards.
+Providers receive rewards based on the [benchmarks](/acurast-processors/benchmarks) of their participating devices. These rewards are paid from Acurast's token inflation. On Canary and Mainnet, a total of 10% of Acurast's inflation are distributed per epoch (900 blocks / roughly every 1.5 hours). This equals to 856.164 tokens per epoch to distributed as Base Benchmark Rewards (Compute Pool) among all Compute Providers, independent of their participation in Staked Compute. These rewards are split up to the different benchmarks pools and each phone competes with the others in the 4 benchmark pools. Higher specs usually lead to higher Base Benchmark Rewards (Compute Pool).
 
 <div>
   <img src="/img/reward_distribution.png" alt="Distribution per Benchmark Metric on Canary Network" />
   <p style={{marginTop: '4px', fontSize: '0.875rem', fontStyle: 'italic', color: '#6b7280'}}>Distribution per Benchmark Metric on Canary Network</p>
 </div>
 
+### Staking Rewards (Staked Compute Pool)
+
+Compute Providers who participate in [Staked Compute](/staked-compute/overview) earn additional rewards by committing their compute power and staking tokens. 70% of Acurast's inflation is distributed as Staking Rewards (Staked Compute Pool) every epoch, which is 5'993.15 tokens. Staking Rewards (Staked Compute Pool) are distributed based on hardware performance, stake size, and commitment duration. Learn more about [how Staked Compute works](/staked-compute/overview) and how to maximize your staking rewards.
+
+<div>
+  <img src="/img/inflation.png" alt="Acurast Inflation Distribution" />
+  <p style={{marginTop: '4px', fontSize: '0.875rem', fontStyle: 'italic', color: '#6b7280'}}>Acurast Inflation Distribution</p>
+</div>
+
 ### Cloud Rebellion
 
 Join the [Cloud Rebellion](https://rebellion.acurast.com/) and harvest MIST points. Become a Rebel and cloud-harvest MIST (points) by completing quests, onboarding Processors, and inviting others to join the Rebellion.
-
-### ~~Bootstrapping~~ (has been sundowned in favor of the Benchmark Rewards)
-
-~~Receive 250 cACU each month in Bootstrapping Rewards. Run your Processor, connected to the internet, for a month and receive 250 cACU in bootstrapping rewards. You will receive a fraction of the full reward each hour.~~

--- a/docs/staked-compute/staking-mechanics.mdx
+++ b/docs/staked-compute/staking-mechanics.mdx
@@ -38,7 +38,7 @@ The measured compute of a Compute Provider is displayed as **Current Compute** o
 
 ### How Benchmarks Are Measured
 
-Compute is measured through four benchmark tests conducted on every device running the Acurast processor. These tests run automatically during each device heartbeat (every 30 minutes) and the results are reported on-chain. At least one valid benchmark report per epoch (900 blocks / roughly 90 minutes) is required to maintain a device's measured compute. Read more about the technical aspects of the benchmarks [here](/acurast-processors/benchmarks).
+Compute is measured through four benchmark tests conducted on every device running the Acurast processor. These tests run automatically during each device heartbeat (every 30 minutes) and the results are reported on-chain. The first valid benchmark report per epoch (900 blocks / roughly 90 minutes) will set a processor's measured compute and deployment activity state for that epoch. Read more about the technical aspects of the benchmarks [here](/acurast-processors/benchmarks).
 
 ### Benchmark Metric Weights
 


### PR DESCRIPTION
## Summary
- Restructured processor rewards documentation with clearer reward categories and updated terminology
- Updated reward section titles to include pool names for clarity
- Added detailed inflation distribution information with specific token amounts
- Clarified benchmark measurement timing and terminology

### Changes to processors/rewards.mdx:
- **Deployment Rewards**: Renamed from "Deployment Execution", clarified that developers pay fees (not provide rewards), changed "selected" to "matched"
- **Base Benchmark Rewards (Compute Pool)**: Renamed from "Benchmark Rewards", added that rewards come from token inflation (10% per epoch = 856.164 tokens), corrected epoch to 900 blocks, clarified independence from Staked Compute participation
- **Staking Rewards (Staked Compute Pool)**: New section explaining 70% inflation distribution (5'993.15 tokens per epoch) with inflation distribution diagram
- Removed deprecated Bootstrapping section

### Changes to staking-mechanics.mdx:
- Updated benchmark measurement explanation: "first valid benchmark report per epoch sets processor's measured compute and deployment activity state"
- Changed "device's" to "processor's" for terminology consistency

## Test plan
- [ ] Verify the documentation renders correctly at http://localhost:3000/processors/rewards
- [ ] Verify the documentation renders correctly at http://localhost:3000/staked-compute/staking-mechanics
- [ ] Check that inflation image displays properly
- [ ] Review all reward amounts and percentages are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)