### PR TITLE
doc: update Canary staking allocation and add conversion warning

### DIFF
--- a/docs/staked-compute/mainnet-vs-canary.mdx
+++ b/docs/staked-compute/mainnet-vs-canary.mdx
@@ -13,7 +13,13 @@ Acurast operates two networks - Mainnet and Canary - each with different staking
 
 ## Staking on Acurast Canary Network
 
-Canary serves as Acurast's testing and experimental network, where new features are deployed and tested before moving to Mainnet. Staking rewards on Canary are significantly smaller, with only 1% of epoch inflation allocated to the Staked Compute Pool, while 99% goes to benchmark rewards. This distribution prioritizes onboarding new devices and testing network behavior over long-term staking incentives.
+Canary serves as Acurast's testing and experimental network, where new features are deployed and tested before moving to Mainnet. Staking rewards on Canary now match Mainnet's allocation, with 70% of epoch inflation allocated to the Staked Compute Pool. This distribution supports testing staking mechanisms with realistic reward structures before deployment to Mainnet.
+
+:::warning Canary Stakes And Conversion to Mainnet
+
+When Mainnet goes live, a 90 days conversion phase starts, allowing users to convert their funds from Canary to Mainnet using the Conversion process. In order to convert staked Canary funds to mainnet, all stakes and delegations on Canary need to be unstaked / undelegated. Users are advised to do that as soon as the conversion phase starts, in order to have enough time to convert. Non converted Canary funds and stakes can not be converted to Mainnet once the Conversion phase has ended.
+
+:::
 
 ## Staking on Acurast Mainnet
 
@@ -21,12 +27,17 @@ Mainnet is Acurast's production network with a mature reward structure designed 
 
 ## Key Parameters Comparison (Mainnet vs. Canary)
 
+:::info
+
+The Canary values are currently set to 1% of inflation and 85.6164 cACU. They will be set to the same as Mainnet on November 4, 2025 12pm UTC.
+
+:::
 
 | Parameter | Canary | Mainnet |
 |-----------|---------|---------|
-| Staked Compute Pool Allocation | 1% of inflation | 70% of inflation |
+| Staked Compute Pool Allocation | 70% of inflation | 70% of inflation |
 | Total Epoch Rewards | 8,561.64 cACU | 8,561.64 ACU |
-| Staking Rewards per Epoch | 85.62 cACU (1% of 8,561.64) | 5,993.15 ACU (70% of 8,561.64) |
+| Staking Rewards per Epoch | 5,993.15 cACU (70% of 8,561.64) | 5,993.15 ACU (70% of 8,561.64) |
 | Min Cooldown Period | 600 blocks (~ 1 hour) | 403,200 blocks (~ 28 days) |
 | Max Cooldown Period | 28,800 blocks (~ 48 hours)| 19,353,600 blocks (~ 1344 days / 3.68 years)|
 | Max Slashing per Epoch | 0.003424657534% of stake | 0.003424657534% of stake |

--- a/docs/staked-compute/staking-mechanics.mdx
+++ b/docs/staked-compute/staking-mechanics.mdx
@@ -181,4 +181,4 @@ Importantly, while rewards are halved during cooldown, slashing penalties are no
 
 ## Reward compounding (Autocompound)
 
-When creating a stake, committers and delegators can choose whether their staking rewards should be automatically compounded (immediately added back to their stake) or made available for withdrawal. If they choose not to autocompound, rewards accumulate and can be withdrawn at any time - users are then free to move these rewards or manually stake them again. Autocompounding simply automates this process, maximizing reward growth over time without requiring manual action.
+When creating a stake, committers and delegators can choose whether their staking rewards should be automatically compounded (automatically added back to their stake) or made available for withdrawal. If they choose not to autocompound, rewards accumulate and can be withdrawn at any time - users are then free to move these rewards or manually stake them again. Autocompounding simply automates this process, maximizing reward growth over time without requiring manual action.


### PR DESCRIPTION
## Summary
- Updated Canary staking parameters to match Mainnet allocation (70%)
- Added important warnings about the 90-day conversion period when Mainnet launches
- Clarified timing of parameter changes with info box
- Minor terminology improvement in staking mechanics

### Changes to mainnet-vs-canary.mdx:
- **Updated allocation**: Changed Canary's Staked Compute Pool Allocation from 1% to 70% to match Mainnet
- **Updated rewards**: Changed Staking Rewards per Epoch from 85.62 cACU to 5,993.15 cACU
- **Revised description**: Updated Canary network description to explain matching allocation supports realistic testing
- **Conversion warning**: Added prominent warning box explaining the 90-day conversion period, requirement to unstake before conversion, and deadline implications
- **Timeline info**: Added informational note clarifying current values (1% inflation, 85.6164 cACU) and upcoming change on November 4, 2025 12pm UTC

### Changes to staking-mechanics.mdx:
- Changed "immediately" to "automatically" in Reward compounding section for better clarity

## Test plan
- [ ] Verify the documentation renders correctly at http://localhost:3000/staked-compute/mainnet-vs-canary
- [ ] Check that warning box displays prominently with proper styling
- [ ] Check that info box displays with proper styling
- [ ] Verify the documentation renders correctly at http://localhost:3000/staked-compute/staking-mechanics
- [ ] Review all values in the comparison table are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)