### PR TITLE
doc: update deployment reward mechanism to execution bonus

### DIFF
--- a/docs/acurast-orchestrator.mdx
+++ b/docs/acurast-orchestrator.mdx
@@ -31,4 +31,6 @@ For example, data can be the observation of a public data point (e.g., from a pu
 
 ## Reward Flow
 
-For the reward flow, the developer defines the budget for the execution of the specified deployment. The budget can be defined in native ACU tokens, or for example, FIAT-pegged stablecoins. This mechanism allows for deterministic financial planning of executions for both the processor andthe developer. The processor automatically receives the reward upon successful execution of deployments.
+For the reward flow, the developer defines the budget for the execution of the specified deployment. The budget can be defined in native cACU/ACU tokens, or later as well, for example, in FIAT-pegged stablecoins. This mechanism allows for deterministic financial planning of executions for developers.
+
+When a deployment is executed, the deployment fee paid by the developer is burnt, creating a deflationary effect on the token supply. Processors executing deployments receive an indirect benefit through a Deployment Execution Bonus: they receive a bonus weight on their Benchmark Metrics that increases their scoring - and therefore their rewards - in both the Staked Compute Pool and the Compute Pool (Base Benchmarking Rewards) for that epoch. This mechanism ensures processors are rewarded for executing deployments while maintaining the deflationary tokenomics of the network.

--- a/docs/processors/rewards.mdx
+++ b/docs/processors/rewards.mdx
@@ -10,10 +10,6 @@ As a Compute Provider running Acurast Processors, you receive rewards for contri
 
 ## Reward Types
 
-### Deployment Rewards
-
-Tokens (cACU on Canary, ACU on Mainnet) are rewarded when a processor's compute power is used by developers to run code. Developers that deploy to the Acurast Cloud pay a fee for the compute power used. When your Processor has been matched and does execute a deployment, you'll receive a share part of those fees collected.
-
 ### Base Benchmark Rewards (Compute Pool)
 
 Providers receive rewards based on the [benchmarks](/acurast-processors/benchmarks) of their participating devices. These rewards are paid from Acurast's token inflation. On Canary and Mainnet, a total of 10% of Acurast's inflation are distributed per epoch (900 blocks / roughly every 1.5 hours). This equals to 856.164 tokens per epoch to distributed as Base Benchmark Rewards (Compute Pool) among all Compute Providers, independent of their participation in Staked Compute. These rewards are split up to the different benchmarks pools and each phone competes with the others in the 4 benchmark pools. Higher specs usually lead to higher Base Benchmark Rewards (Compute Pool).
@@ -31,6 +27,10 @@ Compute Providers who participate in [Staked Compute](/staked-compute/overview) 
   <img src="/img/inflation.png" alt="Acurast Inflation Distribution" />
   <p style={{marginTop: '4px', fontSize: '0.875rem', fontStyle: 'italic', color: '#6b7280'}}>Acurast Inflation Distribution</p>
 </div>
+
+### Deployment Execution Bonus
+
+When a processor is detected executing a deployment during an epoch, it receives a bonus weight on the Benchmark Metrics that increases its scoring - and therefore its rewards - in both the Staked Compute Pool and the Compute Pool (Base Benchmarking Rewards) for that epoch. The deployment fees paid by developers will be burnt, which creates a deflationary effect.
 
 ### Cloud Rebellion
 


### PR DESCRIPTION
## Summary
- Updated documentation to reflect new deployment reward mechanism where fees are burnt and processors receive execution bonuses instead of direct payments
- Restructured processor rewards page for better flow
- Ensured consistency across acurast-orchestrator and processors/rewards pages

### Changes to processors/rewards.mdx:
- **Restructured sections**: Reordered reward types to: Base Benchmark Rewards → Staking Rewards → Deployment Execution Bonus → Cloud Rebellion
- **Renamed section**: Changed "Deployment Rewards" to "Deployment Execution Bonus"
- **Updated mechanism**: Processors now receive bonus weight on Benchmark Metrics instead of direct fee share
- **Fee burning**: Clarified that deployment fees paid by developers are burnt for deflationary effect
- **Bonus impact**: Explained that bonus increases scoring in both Staked Compute Pool and Compute Pool (Base Benchmarking Rewards)

### Changes to acurast-orchestrator.mdx:
- **Updated Reward Flow section**: Completely rewrote to explain new mechanism
- **Token clarity**: Changed "ACU tokens" to "cACU/ACU tokens" for accuracy
- **Future-proofing**: Added "or later as well" for planned stablecoin support
- **Removed outdated info**: Deleted statement about direct reward payments to processors
- **Added new mechanism**: Explained Deployment Execution Bonus, fee burning, and how it maintains deflationary tokenomics
- **Fixed typo**: "andthe" → separate words

## Consistency Note
These changes ensure the documentation is consistent across both pages regarding how deployment rewards work in the current system.

## Test plan
- [ ] Verify the documentation renders correctly at http://localhost:3000/processors/rewards
- [ ] Verify the documentation renders correctly at http://localhost:3000/acurast-orchestrator
- [ ] Check that the new reward mechanism is clearly explained on both pages
- [ ] Verify section ordering on rewards page makes logical sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)