### PR TITLE
doc: mark Ledger and AirGap wallets as coming soon

### DIFF
--- a/docs/wallets/wallets-airgap.mdx
+++ b/docs/wallets/wallets-airgap.mdx
@@ -1,14 +1,14 @@
 ---
-title: AirGap Wallet
+title: AirGap Wallet (soon)
 slug: /wallets/wallets-airgap
 ---
 
 import ThemedImage from "@theme/ThemedImage";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-:::danger IMPORTANT
+:::info AirGap Support Coming Soon
 
-AirGap Wallet can currently only be used to track the balance of an Acurast account, not to connect to the Acurast Hub or to sign transactions. The AirGap team is currently implementing signing and connections to the Hub.
+AirGap is currently not supported and cannot be used to sign transactions on Acurast. This integration is being worked on and is expected to come soon.
 
 :::
 

--- a/docs/wallets/wallets-ledger.mdx
+++ b/docs/wallets/wallets-ledger.mdx
@@ -1,10 +1,16 @@
 ---
-title: Ledger Hardware Wallet
+title: Ledger Hardware Wallet (soon)
 slug: /wallets/wallets-ledger
 ---
 
 import ThemedImage from "@theme/ThemedImage";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+
+:::info Ledger Support Coming Soon
+
+Ledger is currently not supported and cannot be used to sign transactions on Acurast. This integration is being worked on and is expected to come soon.
+
+:::
 
 ### Create an Acurast address with Ledger (and SubWallet)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -105,12 +105,12 @@ const sidebars = {
         {
           type: "doc",
           id: "wallets/wallets-ledger",
-          label: "Ledger",
+          label: "Ledger (soon)",
         },
         {
           type: "doc",
           id: "wallets/wallets-airgap",
-          label: "AirGap",
+          label: "AirGap (soon)",
         },
       ],
       collapsed: true,


### PR DESCRIPTION
## Summary
- Updated Ledger and AirGap wallet documentation to clearly indicate these integrations are not yet available
- Added prominent info boxes and "(soon)" labels throughout to manage user expectations
- Ensured consistent messaging across page titles, sidebar navigation, and warning boxes

### Changes to wallets-ledger.mdx:
- **Page title**: Added "(soon)" suffix
- **New info box**: Added prominent info box at top of page stating "Ledger is currently not supported and cannot be used to sign transactions on Acurast. This integration is being worked on and is expected to come soon."
- Keeps existing setup guide for future reference

### Changes to wallets-airgap.mdx:
- **Page title**: Added "(soon)" suffix  
- **Updated alert box**: Changed from danger box to info box for consistency with Ledger page
- **Simplified message**: Updated to state "AirGap is currently not supported and cannot be used to sign transactions on Acurast. This integration is being worked on and is expected to come soon."
- Maintains cleaner, more consistent messaging

### Changes to sidebars.js:
- **Ledger navigation**: Added "(soon)" to sidebar label
- **AirGap navigation**: Added "(soon)" to sidebar label
- Makes it immediately clear in navigation that these features are not yet available

## User Experience Improvements
These changes ensure users understand the current state of Ledger and AirGap integrations before clicking through to the pages, preventing confusion and setting appropriate expectations.

## Test plan
- [ ] Verify the sidebar shows "Ledger (soon)" and "AirGap (soon)"
- [ ] Verify http://localhost:3000/wallets/wallets-ledger shows info box and updated title
- [ ] Verify http://localhost:3000/wallets/wallets-airgap shows info box and updated title
- [ ] Check that info boxes display with proper styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)