### PR TITLE
doc: clean up and reorganize staking mechanics text

### DIFF
--- a/docs/staked-compute/staking-mechanics.mdx
+++ b/docs/staked-compute/staking-mechanics.mdx
@@ -88,9 +88,6 @@ $
 **Benchmark Metric Pools → Committers**
 
 The share of rewards each committer gets depends on a score calculated from following factors, which can be chosen or influenced by the committer when creating the stake.
-The share of rewards each committer gets depends on a score calculated from following factors, which can be chosen or influenced by the committer when creating the stake.
-
-In short: stronger hardware, bigger stake, longer commitment = bigger rewards.
 
 The reward split is calculated for each Benchmark Metric Pool $p$ separately. The relative score of a participant $c$ compared to other participants is calculated as
 
@@ -113,6 +110,8 @@ $
 \text{reward}_c^{(p)} = \frac{\text{committer\_score}_c^{(p)}}{\sum_c{\text{committer\_score}_c^{(p)}}}
 $
 
+In short: stronger hardware, bigger stake, longer commitment = bigger rewards.
+
 **Delegators Split**
 
 The remaining delegator rewards are split between all delegators of the same committer, according to each delegator's weight. Also the delegation fee is split off to the Committer. The following factors influence delegation rewards for a delegator $d$ towards a committer $c$:
@@ -125,10 +124,9 @@ $
 
 Acurast inflates its token supply every year, by 5% (currently, can be changed by governance). That inflation is split between the following pools:
 
-**On Mainnet:**
 - 70% → Staked Compute Pool (The rewards for Staking)
 - 15% → Treasury
-- 10% → Benchmark rewards (Base rewards processors, shared in relation to the benchmarks, independent from Staking)
+- 10% → Base Benchmark Rewards (independent from Staking)
 - 5% → Acurast blockchain block producers (Collators aka Validators)
 
 <ThemedImage
@@ -137,10 +135,6 @@ Acurast inflates its token supply every year, by 5% (currently, can be changed b
     dark: useBaseUrl("/img/inflation.png"),
   }}
 />
-
-**On Canary:**
-- 1% → Staked Compute Pool (The rewards for Staking)
-- 99% → Benchmark rewards (Base rewards processors, shared in relation to the benchmarks, independent from Staking)
 
 ### When are rewards distributed
 


### PR DESCRIPTION
## Summary
- Cleaned up duplicate and outdated content in the Reward Flow section
- Reorganized text for better logical flow
- Updated terminology for consistency with other documentation
- Removed outdated Canary-specific information now that allocations match Mainnet

### Changes to staking-mechanics.mdx:
- **Removed duplicate**: Eliminated duplicate sentence about committer reward scoring
- **Reorganized summary**: Moved "In short: stronger hardware, bigger stake, longer commitment = bigger rewards" to appear just before the Delegators Split section, providing a natural summary after explaining the reward calculation formulas
- **Simplified terminology**: Changed "Benchmark rewards (Base rewards processors, shared in relation to the benchmarks, independent from Staking)" to "Base Benchmark Rewards (independent from Staking)" for consistency with terminology used elsewhere in docs
- **Removed network labels**: Removed "On Mainnet:" label as it's now redundant since Canary uses the same allocation
- **Removed outdated Canary section**: Deleted the "On Canary:" section that showed 1% Staked Compute Pool / 99% Benchmark rewards split, as Canary now matches Mainnet's 70%/30% allocation

## Impact
These changes improve readability and remove confusion about differences between Canary and Mainnet allocations, since they're now the same.

## Test plan
- [ ] Verify the documentation renders correctly at http://localhost:3000/staked-compute/staking-mechanics
- [ ] Check that the "In short" summary appears in a logical location
- [ ] Verify that only one inflation distribution is shown (not separate for Mainnet/Canary)
- [ ] Confirm no duplicate sentences remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)