### PR TITLE
Add whitepapers page with Acurast and MICA whitepapers

### DIFF
--- a/docs/whitepapers.mdx
+++ b/docs/whitepapers.mdx
@@ -1,0 +1,24 @@
+---
+title: Whitepapers
+slug: /whitepapers
+---
+
+# Whitepapers
+
+## Acurast Whitepaper
+
+**Published:** March 17, 2025
+
+The original Acurast whitepaper introducing the decentralized compute network powered by smartphones and Trusted Execution Environments (TEEs).
+
+[Read on arXiv →](https://arxiv.org/abs/2503.15654)
+
+---
+
+## MICA Whitepaper
+
+**Published:** February 21, 2025
+
+The MICA (Modular Infrastructure for Confidential Applications) whitepaper details the technical architecture and implementation of Acurast's confidential compute infrastructure.
+
+[Read the whitepaper →](https://docsend.com/view/vxyaenm9z2mfghg9)

--- a/sidebars.js
+++ b/sidebars.js
@@ -85,8 +85,9 @@ const sidebars = {
         "integrations",
         "networks",
         "audits",
+        "whitepapers",
       ],
-      collapsed: true,
+      collapsed: false,
     },
     {
       type: "category",


### PR DESCRIPTION
## Summary

- Created new whitepapers page in the Acurast Protocol section
- Added links to both the Acurast and MICA whitepapers with publication dates
- Expanded the Acurast Protocol menu by default in the sidebar

## Changes

### New Whitepapers Page (`docs/whitepapers.mdx`)
- ✅ Added Acurast whitepaper (arXiv) - Published March 17, 2025
- ✅ Added MICA whitepaper - Published February 21, 2025
- ✅ Included descriptions and external links for both papers

### Sidebar Configuration (`sidebars.js`)
- ✅ Added "Whitepapers" entry below "Audits" in Acurast Protocol section
- ✅ Changed Acurast Protocol section to expanded by default (`collapsed: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)