### PR TITLE
Update Transfers on Canary page with wallet information

### DIFF
--- a/docs/from-canary-to-mainnet/token-transfers.mdx
+++ b/docs/from-canary-to-mainnet/token-transfers.mdx
@@ -40,12 +40,12 @@ There are two ways how you can transfer cACU tokens on Canary:
 3. Transfer as usual: select token, enter target address and amount, send
 4. Sign with your wallet
 
-**B) Use the transfer function on [hub.acurast.com](https://hub.acurast.com)**
+**B) Use the transfer function on [hub.acurast.com](https://hub.acurast.com) (e.g. using Metamask or walletconnect enabled wallets)**
 
 1. Go to the balance section of the hub
-2. Click "Transfer"
+2. Click **Transfer**
 3. Enter amount and target address
-4. Click "Transfer" and sign with your wallet
+4. Click **Transfer** and sign with your wallet
 
 **Remember, tokens which are locked by staking cannot be transferred.**
 


### PR DESCRIPTION
## Summary
- Added wallet examples (Metamask, WalletConnect) for the hub.acurast.com transfer method
- Made "Transfer" button text bold for better visibility in step-by-step instructions

## Changes
- Updated option B to clarify that Metamask or WalletConnect enabled wallets can be used with hub.acurast.com
- Made "Transfer" button text bold in steps 2 and 4 for improved readability

## Test plan
- [ ] View the page at http://localhost:3000/from-canary-to-mainnet/token-transfers
- [ ] Verify the wallet information displays correctly in option B
- [ ] Check that bold formatting renders properly for "Transfer" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)