### PR TITLE
Update Canary network documentation

### DIFF
--- a/docs/staked-compute/staking-mechanics.mdx
+++ b/docs/staked-compute/staking-mechanics.mdx
@@ -65,7 +65,7 @@ Staking Rewards trickle down through several pools and are split up:
 
 **Inflation → Staked Compute Pool**
 
-Each epoch, a share of the inflation (70% on Mainnet / 1% on Canary) goes to the Staked Compute Pool. These reward tokens are created by block producers and minted directly into the Staked Compute Pool.
+Each epoch, a share of the inflation (70% on Mainnet and Canary) goes to the Staked Compute Pool. These reward tokens are created by block producers and minted directly into the Staked Compute Pool.
 
 **Staked Compute Pool → 4 Benchmark metric pools**
 


### PR DESCRIPTION
## Summary
- Updated Transfers on Canary page with wallet information (Metamask/WalletConnect clarification)
- Corrected inflation percentage for Canary network in staking mechanics (now 70% same as Mainnet, previously documented as 1%)

## Test plan
- [ ] Review documentation changes for accuracy
- [ ] Verify formatting renders correctly on the docs site
- [ ] Confirm wallet information is clear and helpful for users

🤖 Generated with [Claude Code](https://claude.com/claude-code)