### PR TITLE
Update token page and reorganize staking documentation

### DIFF
--- a/docs/acurast-token.mdx
+++ b/docs/acurast-token.mdx
@@ -12,7 +12,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 The Acurast Token (ACU) is the native utility token of the Acurast network, powering the decentralized compute economy. Acurast is multichain in nature and the token is available on the Acurast mainnet as well as on various other blockchains and ecosystems. Deployed on its native chain, it can be bridged to Ethereum using the Acurast HyperDrive bridge and further from Ethereum to various EVM chains via LayerZero bridges.
 
-### Overview
+## Overview
 ACU serves multiple critical functions within the Acurast ecosystem:
 
 * **Deployment Fees**: Submitted by developers using Acurast Compute
@@ -21,6 +21,7 @@ ACU serves multiple critical functions within the Acurast ecosystem:
 * **Collator rewards**: Rewards for validators and block producers
 * **Cross chain transfers**: Bridged instances of the ACU token, to be moved across various networks
 
+## Token instances
 
 ### ACU on Acurast Mainnet
 
@@ -28,29 +29,29 @@ ACU is the native currency of the Acurast Mainnet, which is Substrate-based Polk
 
 ### ACU on Ethereum
 
-On Ethereum, ACU is available as an ERC20 token, deployed at `0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD`
+On Ethereum, ACU is available as an ERC20 token, deployed at [`0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD`](https://etherscan.io/token/0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD)
 
 Native Acurast tokens from Acurast Mainnet can be bridged to Ethereum and back, using the bridge at [hub.acurast.com](https://hub.acurast.com).
 
 ### ACU on Binance Smart Chain (bridged)
 
-On Binance Smart Chain, ACU, is deployed as a LayerZero OFT, deployed at `0x160C58c70a1c73f769969C63158bcc48547a548B`
+On Binance Smart Chain, ACU, is deployed as a LayerZero OFT, deployed at [`0x160C58c70a1c73f769969C63158bcc48547a548B`](https://bscscan.com/token/0x160C58c70a1c73f769969C63158bcc48547a548B)
 
 ERC20 ACU from Ethereum can be bridged to BSC and back, using the LayerZero bridge.
 
 ### ACU on Base (bridged)
 
-On Base, ACU, is deployed as a Layer Zero OFT, deployed at `0x160C58c70a1c73f769969C63158bcc48547a548B`
+On Base, ACU, is deployed as a Layer Zero OFT, deployed at [`0x160C58c70a1c73f769969C63158bcc48547a548B`](https://basescan.org/token/0x160C58c70a1c73f769969C63158bcc48547a548B)
 
 ERC20 ACU from Ethereum can be bridged to Base and back, using the LayerZero bridge.
 
 ### ACU on Peaq (bridged)
 
-On Peaq, ACU, is deployed as a Layer Zero OFT, deployed at `0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E`
+On Peaq, ACU, is deployed as a Layer Zero OFT, deployed at [`0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E`](https://peaq.subscan.io/account/0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E)
 
 ERC20 ACU from Ethereum can be bridged to Peaq and back, using the LayerZero bridge.
 
-### Bridging pathways and platforms
+## Bridging pathways and platforms
 
 Bridging ACU from and to the native Acurast Mainnet, can be done from and to Ethereum, via the [Acurast HyperDrive](/integrations#level-2) bridge.
 
@@ -64,7 +65,7 @@ ACU from Ethereum can then be bridged via [LayerZero](https://layerzero.network/
 />
 <div class="padding-vert--md"></div>
 
-### Overview of deployed ACU token contracts and instances
+## Overview of deployed ACU token contracts and instances
 
 :::warning CAUTION
 
@@ -72,19 +73,19 @@ Only token contracts listed on the official Acurast documentation are valid Acur
 
 :::
 
-| Chain               | ChainID           | Token Contract                             | Decimals | Type   | Symbol |
-|---------------------|-------------------|--------------------------------------------|----------|--------|--------|
-| Acurast Mainnet     | ParachainID: 3396 | native, no token contract                  | 12       | native | ACU    |
-| Ethereum            | 1 (0x1)           | 0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD | 12       | ERC20  | ACU    |
-| Binance Smart Chain | 56 (0x38)         | 0x160C58c70a1c73f769969C63158bcc48547a548B | 18       | OFT    | ACU    |
-| Base                | 8453 (0x2105)     | 0x160C58c70a1c73f769969C63158bcc48547a548B | 18       | OFT    | ACU    |
-| Peaq                | 3338 (0xd0a)      | 0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E | 18       | OFT    | ACU    |
+| Chain               | ChainID           | Token Contract                             | Decimals | Symbol |
+|---------------------|-------------------|--------------------------------------------|----------|--------|
+| Acurast Mainnet     | ParachainID: 3396 | native, no token contract                  | 12       | ACU    |
+| Ethereum            | 1 (0x1)           | [0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD](https://etherscan.io/token/0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD) | 12       | ACU    |
+| BSC                 | 56 (0x38)         | [0x160C58c70a1c73f769969C63158bcc48547a548B](https://bscscan.com/token/0x160C58c70a1c73f769969C63158bcc48547a548B) | 18       | ACU    |
+| Base                | 8453 (0x2105)     | [0x160C58c70a1c73f769969C63158bcc48547a548B](https://basescan.org/token/0x160C58c70a1c73f769969C63158bcc48547a548B) | 18       | ACU    |
+| Peaq                | 3338 (0xd0a)      | [0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E](https://peaq.subscan.io/account/0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E) | 18       | ACU    |
 
-### ACU token on Coinlist
+## ACU token on Coinlist
 
 On TGE, the ACU tokens for Coinlist sale participants will be withdrawable to Ethereum.
 
-### ACU token on various exchanges
+## ACU token on various exchanges
 
 Exchanges decide which instance of the Acurast token they offer. Carefully study which instance has to be deposited or can be withdrawn before transacting these tokens.
 

--- a/docs/staked-compute/how-to-stake.mdx
+++ b/docs/staked-compute/how-to-stake.mdx
@@ -1,0 +1,43 @@
+---
+title: How To Stake
+slug: /staked-compute/how-to-stake
+---
+
+## How to Stake
+
+On the Staking page in the Acurast Hub, users can stake and have an overview over their Stakes and Delegations.
+
+To create a stake, Compute Providers (aka Committers) have to:
+
+1. Compute: select the amount of Compute they are comfortable to commit.
+2. Cooldown: select the Cooldown period. The cooldown period is measured in blocks. The Staking Frontend also provides an estimate expressed in time (days etc.)
+3. Tokens: Select the amount of tokens to stake
+4. Compound: Select if Autocompoundung is ON or OFF
+
+To do a delegation, Delgators have to:
+
+1. Committer: Select a Committer
+2. Cooldown: Select a Cooldown period
+3. Tokens: Select the amount of tokens to delegate
+4. Compound: Select if Autocompoundung is ON or OFF
+
+## Staking Lifecycle
+
+**Committer:**
+
+* **Start staking:** Committer chooses the amount of computation to commit, tokens to stake, and cooldown length, then creates a stake.
+* **While staking:** Committers can add more tokens to the stake, increase duration and committed compute, and either compound or withdraw rewards. They must maintain their committed compute level to avoid slashing.
+* **Exit staking:** Committer triggers cooldown (reducing rewards to 50% but maintaining full slashing risk) and waits until it ends.
+* **Finalize (Withdraw/Claim):** After cooldown ends, committer finalizes the stake, withdrawing the unlocked funds and any unclaimed rewards.
+
+**Delegator:**
+
+* **Start Staking:** Delegators choose one or several committers to delegate to, then select the amount of tokens and cooldown period (which cannot exceed their chosen committer's cooldown).
+* **While staking:** Delegators can add more tokens, increase duration, compound or withdraw rewards. They can also redelegate their stake to a different committer with equal or greater parameters (committed compute, stake size, and cooldown duration).
+* **Exit staking:** Delegator triggers cooldown (reducing rewards to 50%) and waits until it ends.
+* **Finalize (Withdraw/Claim):** After cooldown ends, delegator finalizes the stake, withdrawing the unlocked funds and any unclaimed rewards.
+
+
+## Reward compounding (Autocompound)
+
+When creating a stake, committers and delegators can choose whether their staking rewards should be automatically compounded (automatically added back to their stake) or made available for withdrawal. If they choose not to autocompound, rewards accumulate and can be withdrawn at any time - users are then free to move these rewards or manually stake them again. Autocompounding simply automates this process, maximizing reward growth over time without requiring manual action.

--- a/docs/staked-compute/overview.mdx
+++ b/docs/staked-compute/overview.mdx
@@ -3,51 +3,20 @@ title: Overview
 slug: /staked-compute/overview
 ---
 
-:::info Under Review
+## Acurast Staked Compute
 
-The content on this page is currently under review and subject to change.
+Acurast is building a decentralized compute network where anyone can contribute processing power using smartphones. To ensure this network stays reliable and doesn't degrade over time, Acurast uses a staking mechanism that creates economic incentives for consistent hardware availability.
 
-:::
+### How It Works
 
-Acurast Staked Compute: Compute Providers commit real hardware + token collateral for a chosen period of time. Delegators can stake with them, and together they share inflation rewards - but both risk slashing if the committer fails to support the deployed hardware long-term. This aligns the incentives to build the world's most accessible, reliable, and decentralized compute network.
+**Compute Providers (Committers)** run the Acurast processor app on actual devices and commit to providing specific compute capacity for a period of time. They stake Acurast tokens as collateral - essentially making a promise backed by Acurast tokens. If they keep their hardware online 24/7 and fulfill their commitment, they earn staking rewards based on their compute amount, stake size, and chosen cooldown duration. If they fail, they lose a portion of their stake through slashing.
 
-## Why Staked Compute matters
+**Delegators** are token holders who don't run hardware but want to support the network. They delegate their tokens to committers they trust, earning a share of the rewards (minus the committer's delegation fee). This helps strengthen providers' commitments while letting more people participate. However, delegators share the risk-if their chosen committer fails, delegators also get slashed proportionally. They can redelegate to different committers anytime.
 
-### Ensuring Network Reliability
+### Why This Matters
 
-Acurast aims to become a global decentralized compute network where anyone can contribute compute power by running the Acurast processor app on dedicated (Core) or personal phones (Lite). The critical challenge is ensuring that provided compute remains consistently available and overall capacity does not degrade over time. Network liveness is essential for building a reliable and powerful infrastructure that developers and users can depend on.
+This creates "skin in the game" for everyone. Providers are economically motivated to maintain their devices and keep capacity online because failure means losing staked capital. Delegators carefully choose reliable providers because they share the consequences.
 
-### Commitment-Based Incentives
+For developers, this means predictable, reliable compute capacity they can build on. Long-term commitments backed by financial collateral ensure the infrastructure will be there when needed.
 
-Staked Compute solves this through economic incentives. Compute Providers commit to supplying a specific amount of compute power - measured by four benchmark metrics - and stake Acurast tokens as collateral for a chosen duration. A stake is fundamentally a promise: providers promise to deliver compute and keep it online 24/7. If they fulfill their promise, they earn staking rewards based on their committed compute, stake size, and commitment duration. If they fail, they lose a portion of their staked tokens through slashing.
-
-This creates "skin in the game" - real economic consequences that align everyone's incentives with network success. Providers are motivated to actively maintain their devices, keep them operational, and replace capacity when needed, because failing to do so means losing their staked capital.
-
-### Building Stability for Developers
-
-The staking mechanism creates the consistent, predictable compute capacity that developers need. Long-term commitments backed by financial collateral ensure reliability. When providers commit for months or years, developers can confidently build applications on Acurast knowing the compute infrastructure will be there when needed.
-
-### Governance and Shared Benefits
-
-In a later phase, staked tokens will grant voting rights in Acurast's governance process through the Acurast DAO. Stakes will represent both economic commitment and voting power in decisions about protocol upgrades, parameter changes, and network strategy.
-
-The system creates a win-win ecosystem: Compute Providers earn rewards for reliable operation, delegators share in rewards without running hardware, and the network becomes more valuable and resilient as participation grows.
-
-## Who can participate
-
-There are two types of participants in Staked Compute:
-
-### Committers
-
-Committers run the Acurast processor app on actual hardware - smartphones- to provide compute and ensure the network's liveness. They stake their own tokens as collateral for their promised computation and receive staking rewards based on their chosen parameters (compute amount, stake size, and cooldown period). Committers can also accept delegations from other Acurast token holders and earn a delegation fee from these additional staked tokens.
-
-If they fail to fulfill their commitment to provide the promised computation power, they can be partially slashed and their stake (and all of their delegators stakes) will be reduced by an defined amount of tokens.
-
-
-### Delegators
-
-Delegators are users who hold Acurast tokens but do not run hardware on the network. They believe in Acurast's value and want to support the network long-term by delegating their tokens (and voting rights) to committers of their choosing. Think of it as lending tokens to strengthen a Compute Provider's commitment. By delegating, they participate in their chosen committer's success and earn staking rewards (minus the committer's delegation fee).
-
-Delegators also share the risk: if their committer fails to deliver on their commitment, delegators can be slashed proportionally. However, delegators can redelegate to another committer at any time if they're concerned about their chosen committer's performance.
-
-Note that committers can also act as delegators, creating one delegation to themselves and additional delegations to other committers - useful for creating multiple stakes with different cooldown periods or risk profiles
+The result is a win-win ecosystem: providers earn rewards for reliability, delegators earn passive income, and the network becomes more valuable as participation grows. Future plans include governance voting rights for staked tokens through the Acurast DAO.

--- a/docs/staked-compute/staking-mechanics.mdx
+++ b/docs/staked-compute/staking-mechanics.mdx
@@ -12,24 +12,6 @@ The content on this page is currently under review and subject to change.
 
 :::
 
-## How to Stake
-
-On the Staking page in the Acurast Hub, users can stake and have an overview over their Stakes and Delegations.
-
-To create a stake, Compute Providers (aka Committers) have to:
-
-1. Compute: select the amount of Compute they are comfortable to commit.
-2. Cooldown: select the Cooldown period. The cooldown period is measured in blocks. The Staking Frontend also provides an estimate expressed in time (days etc.)
-3. Tokens: Select the amount of tokens to stake
-4. Compound: Select if Autocompoundung is ON or OFF
-
-To do a delegation, Delgators have to:
-
-1. Committer: Select a Committer
-2. Cooldown: Select a Cooldown period
-3. Tokens: Select the amount of tokens to delegate
-4. Compound: Select if Autocompoundung is ON or OFF
-
 ## How Compute is measured
 
 ### What is Current Compute?
@@ -173,24 +155,3 @@ When a committer triggers the cooldown period to exit their stake, both their re
 ### Slashing Remains at Full Rate
 
 Importantly, while rewards are halved during cooldown, slashing penalties are not reduced. Committers must continue to maintain their full committed compute throughout the cooldown period, and any shortfalls will result in standard slashing penalties calculated at 100% of the normal rate. This ensures that committers cannot reduce their hardware commitment once they've initiated cooldown - they must maintain their promised compute capacity until the cooldown period ends and they finalize their stake.
-
-## Staking Lifecycle
-
-**Committer:**
-
-* **Start staking:** Committer chooses the amount of computation to commit, tokens to stake, and cooldown length, then creates a stake.
-* **While staking:** Committers can add more tokens to the stake, increase duration and committed compute, and either compound or withdraw rewards. They must maintain their committed compute level to avoid slashing.
-* **Exit staking:** Committer triggers cooldown (reducing rewards to 50% but maintaining full slashing risk) and waits until it ends.
-* **Finalize (Withdraw/Claim):** After cooldown ends, committer finalizes the stake, withdrawing the unlocked funds and any unclaimed rewards.
-
-**Delegator:**
-
-* **Start Staking:** Delegators choose one or several committers to delegate to, then select the amount of tokens and cooldown period (which cannot exceed their chosen committer's cooldown).
-* **While staking:** Delegators can add more tokens, increase duration, compound or withdraw rewards. They can also redelegate their stake to a different committer with equal or greater parameters (committed compute, stake size, and cooldown duration).
-* **Exit staking:** Delegator triggers cooldown (reducing rewards to 50%) and waits until it ends.
-* **Finalize (Withdraw/Claim):** After cooldown ends, delegator finalizes the stake, withdrawing the unlocked funds and any unclaimed rewards.
-
-
-## Reward compounding (Autocompound)
-
-When creating a stake, committers and delegators can choose whether their staking rewards should be automatically compounded (automatically added back to their stake) or made available for withdrawal. If they choose not to autocompound, rewards accumulate and can be withdrawn at any time - users are then free to move these rewards or manually stake them again. Autocompounding simply automates this process, maximizing reward growth over time without requiring manual action.

--- a/sidebars.js
+++ b/sidebars.js
@@ -53,6 +53,7 @@ const sidebars = {
       label: "Staked Compute",
       items: [
         "staked-compute/overview",
+        "staked-compute/how-to-stake",
         "staked-compute/staking-mechanics",
         "staked-compute/slashing",
         "staked-compute/mainnet-vs-canary",


### PR DESCRIPTION
## Summary
- Enhanced token page with block explorer links for all chains
- Reorganized staking documentation for better clarity and usability
- Created new "How To Stake" page with practical instructions

## Changes to Token Page
- Added clickable block explorer links for token contracts on all chains:
  - Ethereum: Etherscan
  - BSC: BSCScan  
  - Base: BaseScan
  - Peaq: Peaq Subscan
- Made token addresses clickable in both sections and overview table
- Restructured headings (promoted key sections to H2 level)
- Added "Token instances" section for better organization
- Removed "Type" column from contracts table
- Renamed "Binance Smart Chain" to "BSC" for consistency

## Changes to Staking Documentation
- Simplified staked compute overview with more concise, accessible content
- Updated terminology: "commitment duration" → "cooldown duration" throughout
- Created new dedicated "How To Stake" page with:
  - Step-by-step staking instructions for committers and delegators
  - Complete staking lifecycle explanation
  - Reward compounding (autocompound) guide
- Moved practical user-facing content from "Staking Mechanics" to "How To Stake"
- Better separation between technical mechanics and user instructions

## Test plan
- [x] Verify all block explorer links work correctly
- [x] Check token page displays properly with new structure
- [x] Confirm "How To Stake" page appears in navigation
- [x] Validate content moved from staking mechanics displays correctly
- [x] Test local dev server builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)