### PR TITLE
Update token contract addresses to coming soon status

### DIFF
--- a/docs/acurast-token.mdx
+++ b/docs/acurast-token.mdx
@@ -35,19 +35,19 @@ Native Acurast tokens from Acurast Mainnet can be bridged to Ethereum and back, 
 
 ### ACU on Binance Smart Chain (bridged)
 
-On Binance Smart Chain, ACU, is deployed as a LayerZero OFT, deployed at [`0x160C58c70a1c73f769969C63158bcc48547a548B`](https://bscscan.com/token/0x160C58c70a1c73f769969C63158bcc48547a548B)
+On Binance Smart Chain, ACU, is deployed as a LayerZero OFT (coming soon)
 
 ERC20 ACU from Ethereum can be bridged to BSC and back, using the LayerZero bridge.
 
 ### ACU on Base (bridged)
 
-On Base, ACU, is deployed as a Layer Zero OFT, deployed at [`0x160C58c70a1c73f769969C63158bcc48547a548B`](https://basescan.org/token/0x160C58c70a1c73f769969C63158bcc48547a548B)
+On Base, ACU, is deployed as a Layer Zero OFT (coming soon)
 
 ERC20 ACU from Ethereum can be bridged to Base and back, using the LayerZero bridge.
 
 ### ACU on Peaq (bridged)
 
-On Peaq, ACU, is deployed as a Layer Zero OFT, deployed at [`0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E`](https://peaq.subscan.io/account/0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E)
+On Peaq, ACU, is deployed as a Layer Zero OFT (coming soon)
 
 ERC20 ACU from Ethereum can be bridged to Peaq and back, using the LayerZero bridge.
 
@@ -77,9 +77,9 @@ Only token contracts listed on the official Acurast documentation are valid Acur
 |---------------------|-------------------|--------------------------------------------|----------|--------|
 | Acurast Mainnet     | ParachainID: 3396 | native, no token contract                  | 12       | ACU    |
 | Ethereum            | 1 (0x1)           | [0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD](https://etherscan.io/token/0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD) | 12       | ACU    |
-| BSC                 | 56 (0x38)         | [0x160C58c70a1c73f769969C63158bcc48547a548B](https://bscscan.com/token/0x160C58c70a1c73f769969C63158bcc48547a548B) | 18       | ACU    |
-| Base                | 8453 (0x2105)     | [0x160C58c70a1c73f769969C63158bcc48547a548B](https://basescan.org/token/0x160C58c70a1c73f769969C63158bcc48547a548B) | 18       | ACU    |
-| Peaq                | 3338 (0xd0a)      | [0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E](https://peaq.subscan.io/account/0x58A359e8C67Dd5b639Fb7d47CD9AD347A7C2F71E) | 18       | ACU    |
+| BSC                 | 56 (0x38)         | (coming soon)                              | 12       | ACU    |
+| Base                | 8453 (0x2105)     | (coming soon)                              | 12       | ACU    |
+| Peaq                | 3338 (0xd0a)      | (coming soon)                              | 12       | ACU    |
 
 ## ACU token on Coinlist
 


### PR DESCRIPTION
## Summary
- Updated BSC, Base, and Peaq token contract addresses to show "(coming soon)" 
- Kept Ethereum contract address visible as requested
- Standardized all token decimals to 12 across all chains (BSC, Base, and Peaq were previously 18)

## Changes
- **Text sections**: Replaced contract addresses with "(coming soon)" for BSC, Base, and Peaq
- **Table**: Updated contract addresses and decimals for BSC, Base, and Peaq
- **Ethereum**: No changes - contract address remains visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)