### PR TITLE
Add LayerZero OFT contract addresses for BSC, Base, and Peaq

### DIFF
--- a/docs/acurast-token.mdx
+++ b/docs/acurast-token.mdx
@@ -35,19 +35,19 @@ Native Acurast tokens from Acurast Mainnet can be bridged to Ethereum and back, 
 
 ### ACU on Binance Smart Chain (bridged)
 
-On Binance Smart Chain, ACU, is deployed as a LayerZero OFT (coming soon)
+On Binance Smart Chain, ACU is deployed as a LayerZero OFT at [`0x6EF2FFB38D64aFE18ce782DA280b300e358CFeAF`](https://bscscan.com/token/0x6EF2FFB38D64aFE18ce782DA280b300e358CFeAF)
 
 ERC20 ACU from Ethereum can be bridged to BSC and back, using the LayerZero bridge.
 
 ### ACU on Base (bridged)
 
-On Base, ACU, is deployed as a Layer Zero OFT (coming soon)
+On Base, ACU is deployed as a LayerZero OFT at [`0xc5fEd7c8cCC75D8A72b601a66DffD7A489073F0b`](https://basescan.org/token/0xc5fEd7c8cCC75D8A72b601a66DffD7A489073F0b)
 
 ERC20 ACU from Ethereum can be bridged to Base and back, using the LayerZero bridge.
 
 ### ACU on Peaq (bridged)
 
-On Peaq, ACU, is deployed as a Layer Zero OFT (coming soon)
+On Peaq, ACU is deployed as a LayerZero OFT at [`0x165bcb970836F83c15b22c3c1622279d97A20446`](https://peaq.subscan.io/account/0x165bcb970836F83c15b22c3c1622279d97A20446)
 
 ERC20 ACU from Ethereum can be bridged to Peaq and back, using the LayerZero bridge.
 
@@ -77,9 +77,9 @@ Only token contracts listed on the official Acurast documentation are valid Acur
 |---------------------|-------------------|--------------------------------------------|----------|--------|
 | Acurast Mainnet     | ParachainID: 3396 | native, no token contract                  | 12       | ACU    |
 | Ethereum            | 1 (0x1)           | [0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD](https://etherscan.io/token/0x216b3643ff8b7BB30d8A48E9F1BD550126202AdD) | 12       | ACU    |
-| BSC                 | 56 (0x38)         | (coming soon)                              | 12       | ACU    |
-| Base                | 8453 (0x2105)     | (coming soon)                              | 12       | ACU    |
-| Peaq                | 3338 (0xd0a)      | (coming soon)                              | 12       | ACU    |
+| BSC                 | 56 (0x38)         | [0x6EF2FFB38D64aFE18ce782DA280b300e358CFeAF](https://bscscan.com/token/0x6EF2FFB38D64aFE18ce782DA280b300e358CFeAF) | 12       | ACU    |
+| Base                | 8453 (0x2105)     | [0xc5fEd7c8cCC75D8A72b601a66DffD7A489073F0b](https://basescan.org/token/0xc5fEd7c8cCC75D8A72b601a66DffD7A489073F0b) | 12       | ACU    |
+| Peaq                | 3338 (0xd0a)      | [0x165bcb970836F83c15b22c3c1622279d97A20446](https://peaq.subscan.io/account/0x165bcb970836F83c15b22c3c1622279d97A20446) | 12       | ACU    |
 
 ## ACU token on Coinlist
 


### PR DESCRIPTION
## Summary
- Added deployed AcuOFT contract addresses for BSC, Base, and Peaq networks
- Updated both network-specific sections and the overview table with clickable links to block explorers
- Replaced "coming soon" placeholders with actual contract addresses

## Changes
- **BSC**: Added contract address `0x6EF2FFB38D64aFE18ce782DA280b300e358CFeAF` with BSCScan link
- **Base**: Added contract address `0xc5fEd7c8cCC75D8A72b601a66DffD7A489073F0b` with BaseScan link
- **Peaq**: Added contract address `0x165bcb970836F83c15b22c3c1622279d97A20446` with Peaq Subscan link

## Test plan
- [x] Verify all contract addresses are correctly displayed on the token page
- [x] Confirm all block explorer links navigate to the correct addresses
- [x] Check that the table formatting is correct and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)