### PR TITLE
docs: update reward model and device counts

### DIFF
--- a/docs/acurast-orchestrator.mdx
+++ b/docs/acurast-orchestrator.mdx
@@ -8,29 +8,18 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 The Acurast Orchestrator is a centerpiece of the consensus layer, combining the orchestration (i.e., the scheduling of deployments and enabling the liquid matching) of the Processor’s computational resources and Developers. The orchestrator plays an essential role in the definition, agreement, and enforcement of value exchange between processors and developers.
 
-The orchestrator is where the liquid matching engine pairs the advertised processor resources with the defined requirements of the developers. The orchestrator natively supports various price-finding mechanisms (e.g., auctions and advertisements), making DevEx highly accessible and seamless.
+The orchestrator is where the liquid matching engine pairs the advertised processor resources with the defined requirements of the developers. The orchestrator natively supports various price-finding mechanisms (e.g., auctions and advertisements), making Developer Experience (DevEx) highly accessible and seamless.
 
-Every agreement between processor and developer is specified in an entity called deployment. The deployment specifies (i) a set of instructions that are executed on the processor, (ii) its scheduling parameters, and (iii) settlement configuration (i.e., where the output is further processed or persisted), and (iv) finally, the rewards.
+Every agreement between processor and developer is specified in an entity called deployment. The deployment specifies (i) a set of instructions that are executed on the processor, (ii) its scheduling parameters, and (iii) the destination configuration (i.e., where the output is further processed or persisted).
 
-**The orchestrator reward is a core mechanism of the Acurast Protocol, formed by two flows**
+## Compute Costs & Rewards
 
-1. The compute/data flow
-1. The reward flow
+When scheduling a deployment, the developer defines the compute cost for the execution. The cost can be defined in native cACU/ACU tokens, or in FIAT-pegged stablecoins. This mechanism allows for deterministic financial planning of executions for developers.
 
-<ThemedImage
-  alt="Docusaurus themed image"
-  sources={{
-    light: useBaseUrl("/img/acurast-orchestrator-flows_light.svg"),
-    dark: useBaseUrl("/img/acurast-orchestrator-flows_dark.svg"),
-  }}
-/>
+:::info
 
-## Compute/Data Flow
+**All compute costs are paid as gas (transaction) fees. There is no direct reward flow from developers to processors.**
 
-For example, data can be the observation of a public data point (e.g., from a public API), an off-chain computation, the privacy-preserving querying of proprietary data (i.e., permissioned data), or even a combination of all these subcases. From the DevEx and developer’s perspective, it can be compared to defining requirements with a public cloud provider like e.g., Amazon Web Services, Google Cloud or Microsoft Azure.
+:::
 
-## Reward Flow
-
-For the reward flow, the developer defines the budget for the execution of the specified deployment. The budget can be defined in native cACU/ACU tokens, or later as well, for example, in FIAT-pegged stablecoins. This mechanism allows for deterministic financial planning of executions for developers.
-
-When a deployment is executed, the deployment fee paid by the developer is burnt, creating a deflationary effect on the token supply. Processors executing deployments receive an indirect benefit through a Deployment Execution Bonus: they receive a bonus weight on their Benchmark Metrics that increases their scoring - and therefore their rewards - in both the Staked Compute Pool and the Compute Pool (Base Benchmarking Rewards) for that epoch. This mechanism ensures processors are rewarded for executing deployments while maintaining the deflationary tokenomics of the network.
+Instead, processors earn rewards through the **[staking pools](/staked-compute/overview)**. When processors execute deployments, they receive a [Deployment Execution Bonus](/processors/rewards#deployment-execution-bonus): a bonus weight on their Benchmark Metrics that increases their scoring—and therefore their share of rewards—in both the Staked Compute Pool and the Compute Pool (Base Benchmarking Rewards) for that epoch. This mechanism ensures processors are incentivized to execute deployments and burn gas fees.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -11,7 +11,7 @@ slug: /faq
 
 Acurast is redefining compute by utilizing billions of smartphones – no data centers required. This verifiable, scalable, and confidential compute network enables users to run secure applications on decentralized infrastructure at scale—without compromising speed or privacy.
 
-Acurast has already onboarded 158,139+ compute units worldwide on its incentivized testnet making it the most decentralized verifiable compute network available today. This impressive amount of compute already powers mission critical workloads with high-security and AI requirements.
+Acurast has already onboarded 165,000+ compute units worldwide on its incentivized testnet making it the most decentralized verifiable compute network available today. This impressive amount of compute already powers mission critical workloads with high-security and AI requirements.
 
 This isn’t just another DePIN protocol — it’s a game-changer that’s redefining how the world computes.
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -22,7 +22,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 Acurast is redefining compute by utilizing billions of smartphones – no data centers required. This verifiable, scalable, and confidential compute network enables users to run secure applications on decentralized infrastructure at scale—without compromising speed or privacy.
 
-Acurast has already onboarded 158,139+ compute units worldwide on its incentivized testnet making it the most decentralized verifiable compute network available today. This impressive amount of compute already powers mission critical workloads with high-security and AI requirements.
+Acurast has already onboarded 165,000+ compute units worldwide on its incentivized testnet making it the most decentralized verifiable compute network available today. This impressive amount of compute already powers mission critical workloads with high-security and AI requirements.
 
 This isn’t just another DePIN protocol — it’s a game-changer that’s redefining how the world computes.
 

--- a/docs/processors/rewards.mdx
+++ b/docs/processors/rewards.mdx
@@ -30,7 +30,7 @@ Compute Providers who participate in [Staked Compute](/staked-compute/overview) 
 
 ### Deployment Execution Bonus
 
-When a processor is detected executing a deployment during an epoch, it receives a bonus weight on the Benchmark Metrics that increases its scoring - and therefore its rewards - in both the Staked Compute Pool and the Compute Pool (Base Benchmarking Rewards) for that epoch. The deployment fees paid by developers will be burnt, which creates a deflationary effect.
+When a processor is detected executing a deployment during an epoch, it receives a bonus weight on the Benchmark Metrics that increases its scoring - and therefore its rewards - in both the Staked Compute Pool and the Compute Pool (Base Benchmarking Rewards) for that epoch. The deployment costs are paid as gas fees (i.e., transaction fees) by the developers. The protocol burns these fees.
 
 ### Cloud Rebellion
 

--- a/docs/tokenomics.mdx
+++ b/docs/tokenomics.mdx
@@ -75,11 +75,11 @@ Only tokens allocated to the community and community support will unlock at TGE.
 
 ## Token Utility
 
-**Network Fees:** The Acurast network, a Proof of Stake blockchain, acts as an orchestrator and settlement layer for the decentralized compute economy. To interact with the Acurast network, ACU is required for transaction fees.
+**Network Fees:** The Acurast network, a Proof of Stake blockchain, acts as an orchestrator for the decentralized compute economy. To interact with the Acurast network, ACU is required for gas fees (*i.e.,* transaction fees).
 
-**Staking:** While compute is secured by design, an additional layer of economic security is added to the network by staking through Processors. Stakers receive fees from the network as rewards for providing economic security to the network. Every ACU holder can participate in staking without having to run their own Processor through Delegation.
+**Staking:** Processors and delegators stake ACU to participate in the [Staked Compute Pool](/staked-compute/overview), earning rewards from epoch inflation for providing and securing compute capacity. Every ACU holder can participate through Delegation without running their own Processor.
 
-**Settlement:** ACU acts as a unified settlement token for the system to assign and measure reputation and quality of service of the provided compute. A 30% burn is applied on every settlement transaction to avoid reputation score tampering. This mechanism is abstracted from the end user, making payment for decentralized compute on Acurast possible in any token.
+**Compute Costs:** When developers schedule deployments, compute costs are paid as gas fees and burned. Processors are rewarded through [Staking Rewards (Staked Compute Pool)](/staked-compute/overview) and [Base Benchmark Rewards (Compute Pool)](/processors/rewards) based on their execution performance.
 
 **Governance:** Holders of ACU can engage in protocol governance by voting on a variety of proposals brought forward by the community, guiding the development of the protocol and its components, and ensuring true decentralization and future-proof evolution by design.
 


### PR DESCRIPTION
   - Clarify that compute costs are paid as gas fees (no direct reward flow from developers to processors)
   - Update device count to 165,000+
   - Revise token utility descriptions for staking and compute costs"