### PR TITLE
docs: update networks page and staking documentation

### DIFF
--- a/docs/acurast-token.mdx
+++ b/docs/acurast-token.mdx
@@ -83,7 +83,7 @@ Only token contracts listed on the official Acurast documentation are valid Acur
 
 ## ACU token on Coinlist
 
-On TGE, the ACU tokens for Coinlist sale participants will be withdrawable to Ethereum.
+After TGE, the ACU tokens for Coinlist sale participants will be withdrawable to Ethereum.
 
 ## ACU token on various exchanges
 

--- a/docs/networks.mdx
+++ b/docs/networks.mdx
@@ -5,13 +5,21 @@ slug: /networks
 
 A list of all related core infrastrucuture for each deployed Acurast network. More details on the functionalities of each network can be found in the [Protocol Architecture ↗](/acurast-protocol/architecture/instances)
 
+## Acurast Mainnet
+
+|          | Details                                                          |
+| -------- | ---------------------------------------------------------------- |
+| Token    | ACU                                                              |
+| RPC      | [wss://public-rpc.mainnet.acurast.com](wss://public-rpc.mainnet.acurast.com)                  |
+| Explorer | [Block Explorer](https://acurastbot.com/explorer)                |
+
 ## Acurast Canary
 
 |          | Details                                                                                                       |
 | -------- | ------------------------------------------------------------------------------------------------------------- |
 | Token    | cACU                                                                                                          |
-| RPC      | [RPC URL](wss://public-rpc.canary.acurast.com)                                                    |
-| Explorer | [Block Explorer](https://polkadot.js.org/apps/?rpc=wss://public-rpc.canary.acurast.com#/explorer) |
+| RPC      | [wss://public-rpc.canary.acurast.com](wss://public-rpc.canary.acurast.com)                                                    |
+| Explorer | [Block Explorer](https://canary.acurastbot.com/explorer) |
 | Faucet   | [faucet.acurast.com](https://faucet.acurast.com/)                                                             |
 
 ## Acurast Devnet
@@ -19,5 +27,10 @@ A list of all related core infrastrucuture for each deployed Acurast network. Mo
 |          | Details                                                                                                |
 | -------- | ------------------------------------------------------------------------------------------------------ |
 | Token    | dACU                                                                                                   |
-| RPC      | [RPC URL](wss://acurast-devnet-ws.prod.gke.papers.tech)                                                    |
+| RPC      | [wss://acurast-devnet-ws.prod.gke.papers.tech](wss://acurast-devnet-ws.prod.gke.papers.tech)                                                    |
 | Explorer | [Block Explorer](https://polkadot.js.org/apps/?rpc=wss://acurast-devnet-ws.prod.gke.papers.tech#/explorer) |
+
+
+:::note
+Public RPC nodes might be rate-limited. If you run into issues for your use case, please reach out in the community channels.
+:::

--- a/docs/staked-compute/mainnet-vs-canary.mdx
+++ b/docs/staked-compute/mainnet-vs-canary.mdx
@@ -7,7 +7,7 @@ Acurast operates two networks - Mainnet and Canary - each with different staking
 
 ## Staking on Acurast Canary Network
 
-Canary serves as Acurast's testing and experimental network, where new features are deployed and tested before moving to Mainnet. Staking rewards on Canary now match Mainnet's allocation, with 70% of epoch inflation allocated to the Staked Compute Pool. This distribution supports testing staking mechanisms with realistic reward structures before deployment to Mainnet.
+Canary serves as Acurast's testing and experimental network, where new features are deployed and tested before moving to Mainnet. Staking on Canary pays 5% of the inflation of 856.16 cACU per epoch.
 
 :::warning Canary Stakes And Conversion to Mainnet
 
@@ -17,21 +17,17 @@ When Mainnet goes live, a 90 days conversion phase starts, allowing users to con
 
 ## Staking on Acurast Mainnet
 
-Mainnet is Acurast's production network with a mature reward structure designed for long-term sustainability. Here, 70% of epoch inflation goes to the Staked Compute Pool (staking rewards), while the remaining inflation is distributed to: 15% Treasury, 10% Benchmark rewards, and 5% Collators (block producers). This higher allocation to staked compute reflects Mainnet's focus on securing reliable, committed compute capacity.
+Mainnet is Acurast's production network with a mature reward structure designed for long-term sustainability. Here, 70% of epoch inflation goes to the Staked Compute Pool (staking rewards), while the remaining inflation is distributed to: 15% Treasury, 10% Benchmark rewards, and 5% Collators (block producers).
 
 ## Key Parameters Comparison (Mainnet vs. Canary)
 
-:::info
-
-The Canary values are currently set to 1% of inflation and 85.6164 cACU. They will be set to the same as Mainnet on November 4, 2025 12pm UTC.
-
-:::
-
 | Parameter | Canary | Mainnet |
 |-----------|---------|---------|
-| Staked Compute Pool Allocation | 70% of inflation | 70% of inflation |
-| Total Epoch Rewards | 8,561.64 cACU | 8,561.64 ACU |
-| Staking Rewards per Epoch | 5,993.15 cACU (70% of 8,561.64) | 5,993.15 ACU (70% of 8,561.64) |
+| Total Epoch Rewards (100%) | 856.16 cACU | 8,561.64 ACU |
+| Staking Rewards per Epoch | 42.81 cACU (5% of 856.16) | 5,993.15 ACU (70% of 8,561.64) |
+| Base Benchmark Rewards | 0 cACU (0%) | 856.16 ACU (10%) |
+| Collator Rewards | 0 cACU (0%) | 428.08 ACU (5%) |
+| Treasury | 813.35 cACU (95%) | 1,284.25 ACU (15%) |
 | Min Cooldown Period | 600 blocks (~ 1 hour) | 403,200 blocks (~ 28 days) |
 | Max Cooldown Period | 28,800 blocks (~ 48 hours)| 19,353,600 blocks (~ 1344 days / 3.68 years)|
 | Max Slashing per Epoch | 0.003424657534% of stake | 0.003424657534% of stake |

--- a/docs/staked-compute/staking-glossary.mdx
+++ b/docs/staked-compute/staking-glossary.mdx
@@ -25,7 +25,7 @@ A Committers commitment, backed by an amount of Committed Compute, an amount of 
 Four standardized tests that measure a device's computational capacity: CPU Single Core (0.2307 weight), CPU Multi Core (0.2307 weight), RAM Size (0.4615 weight), and Storage Size (0.0769 weight). These metrics are measured during every device heartbeat and reported on-chain to determine Current Compute and calculate rewards and slashing.
 
 ### Current Compute
-The amount of compute that was measured across all processors in the last epoch for a specific Compute Provider. During that epoch, all devices ideally had written three heartbeats including three benchmark results. In order to determine the Current Compute for an epoch the ??? latest ??? recorded heartbeat off all devices are being used.
+The amount of compute that was measured across all processors in the last epoch for a specific Compute Provider. During that epoch, all devices ideally had written three heartbeats including three benchmark results. In order to determine the Current Compute for an epoch, the first recorded heartbeat of each device is being used.
 
 ### Committed Compute
 The amount of compute a Compute Provider commits to providing during the lifetime of a Stake, including its Cooldown period.
@@ -45,7 +45,7 @@ The process of signaling the intention to end a Stake. Unstaking triggers the Co
 The process of withdrawing a stake after the cooldown period has ended, returning the unlocked tokens and any unclaimed rewards to the staker or delegator. Also called "claiming a finalized stake."
 
 ### Recommit
-After starting cooldown on a stake, users can choose to recommit if they change their mind. Recommitting immediately restores reward weight and vote weight to 100% and resets the cooldown countdown, returning the stake to its active state.
+Stakes in cooldown cannot be recommitted. After the cooldown ended, they can be finalized and withdrawn.
 
 ## Rewards & Penalties
 
@@ -71,6 +71,8 @@ A percentage of the slashed amount, that is given to the Slasher as a reward for
 
 ### Redelegate
 Detaching a running Delegation from one Committer and attaching it to a new Committer. Can only be done if the new Committer shares the exact same or higher parameters (Committed Compute, Staked Tokens, Cooldown duration) than the previous Committer and is not in Cooldown.
+
+Redelegation can only be done if the current delegation is older than 7 days or if the stake of the chosen Committer is in cooldown.
 
 ### Delegation Fee
 A fee Committers can set once upon creating a Stake and will receive from the rewards of the Delegations attached to their stake. The Delegation fee cannot be increased during the lifetime of a Stake, but it can be decreased.

--- a/docs/staked-compute/staking-mechanics.mdx
+++ b/docs/staked-compute/staking-mechanics.mdx
@@ -73,7 +73,7 @@ Staking Rewards trickle down through several pools and are split up:
 
 **Inflation → Staked Compute Pool**
 
-Each epoch, a share of the inflation (70% on Mainnet and Canary) goes to the Staked Compute Pool. These reward tokens are created by the protocol and minted directly into the Staked Compute Pool.
+Each epoch, a share of the inflation (70% on Mainnet and 5% on Canary) goes to the Staked Compute Pool. These reward tokens are created by the protocol and minted directly into the Staked Compute Pool.
 
 **Staked Compute Pool → 4 Benchmark metric pools**
 
@@ -148,7 +148,7 @@ $
 
 ### Where the rewards come from
 
-Acurast inflates its token supply every year, by 5% (currently, can be changed by governance). That inflation is split between the following pools:
+Acurast inflates its token supply every year, by 5% (currently, can be changed by governance). On Acurast Mainnet, that inflation is split between the following pools:
 
 - 70% → Staked Compute Pool (The rewards for Staking)
 - 15% → Treasury


### PR DESCRIPTION
- Add Acurast Mainnet to networks page with RPC and explorer links
- Update RPC URLs to display actual endpoints instead of generic labels
- Update Canary explorer to use acurastbot.com
- Add rate-limiting note for public RPC nodes
- Update staking reward percentages (5% on Canary, 70% on Mainnet)
- Update epoch rewards table with correct Canary values
- Add Treasury, Base Benchmark, and Collator reward rows
- Fix staking glossary entries for Current Compute, Recommit, and Redelegate
- Update token page TGE reference