### PR TITLE
feat: improve LLM discoverability

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,8 @@
+{
+  "projectTitle": "Acurast",
+  "description": "Real Decentralized Compute Network powered by smartphones. Serverless deployments, confidential computing, and LLM workloads on mobile TEEs.",
+  "branch": "main",
+  "folders": ["docs"],
+  "excludeFolders": ["node_modules", ".github", "src", "plugins", "scripts"],
+  "excludeFiles": ["CHANGELOG.md"]
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,17 +168,15 @@ const config = {
     [
       'docusaurus-plugin-llms',
       {
-        // Options here
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
         docsDir: 'docs',
         title: 'Acurast Documentation',
-        description: 'Complete reference documentation for Acurast',
+        description: 'Complete reference documentation for Acurast - the Real Decentralized Compute Network powered by smartphones.',
         includeBlog: false,
-
-        // Content cleaning options
         excludeImports: true,
         removeDuplicateHeadings: true,
+        rootContent: `Acurast is the Real Decentralized Compute Network — scalable, secure, and powered by smartphones. It uses Trusted Execution Environments (TEEs) on mobile devices to provide verifiable and confidential computation. Developers deploy serverless workloads (including LLMs) via the Acurast CLI. Compute Providers earn rewards by running a processor app on their phones. The network is secured by staked compute and the ACU token.`,
       },
     ], [
       "@docusaurus/plugin-client-redirects",

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,29 @@
+User-agent: *
+Allow: /
+
+# AI Crawlers - Explicitly Allowed
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+Sitemap: https://docs.acurast.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Enhanced `docusaurus-plugin-llms` config with `rootContent` and improved description
- Added `static/robots.txt` explicitly allowing AI crawlers (GPTBot, ClaudeBot, PerplexityBot, etc.)
- Added `context7.json` for Context7 indexing

## Test plan
- [x] `npm run build` succeeds
- [x] `build/llms.txt` and `build/llms-full.txt` generated with correct content
- [x] `build/robots.txt` present
- [ ] After deploy, verify https://docs.acurast.com/llms.txt and https://docs.acurast.com/robots.txt are accessible